### PR TITLE
Config Unit Tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "args": [
                 "-r",
                 "ts-node/register",
-                "${workspaceFolder}/test/*.ts",
+                "${workspaceFolder}/test/e2e/*.ts",
                 "${workspaceFolder}/test/unit/*.ts",
                 "--exit"
             ],

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 [![Greenkeeper badge](https://badges.greenkeeper.io/ethereum-alarm-clock/timenode-core.svg)](https://greenkeeper.io/)
 
+[![Coverage Status](https://coveralls.io/repos/github/ethereum-alarm-clock/timenode-core/badge.svg?branch=master)](https://coveralls.io/github/ethereum-alarm-clock/timenode-core?branch=master)
+
 # timenode-core
 
 This package contains all of the key logic necessary for the operation of an [Ethereum Alarm Clock](https://github.com/ethereum-alarm-clock/ethereum-alarm-clock) TimeNode. 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 [<img src="https://s3.amazonaws.com/chronologic.network/ChronoLogic_logo.svg" width="128px">](https://github.com/chronologic)
 
 [![npm version](https://badge.fury.io/js/timenode-core.svg)](https://badge.fury.io/js/timenode-core)
-
 [![Greenkeeper badge](https://badges.greenkeeper.io/ethereum-alarm-clock/timenode-core.svg)](https://greenkeeper.io/)
-
 [![Coverage Status](https://coveralls.io/repos/github/ethereum-alarm-clock/timenode-core/badge.svg?branch=master)](https://coveralls.io/github/ethereum-alarm-clock/timenode-core?branch=master)
 
 # timenode-core

--- a/package-lock.json
+++ b/package-lock.json
@@ -214,6 +214,15 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
+    "accepts": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+      "requires": {
+        "mime-types": "2.1.18",
+        "negotiator": "0.6.1"
+      }
+    },
     "aes-js": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-0.2.4.tgz",
@@ -241,7 +250,6 @@
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-      "dev": true,
       "requires": {
         "co": "4.6.0",
         "fast-deep-equal": "1.1.0",
@@ -360,6 +368,11 @@
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
     "array-uniq": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
@@ -381,14 +394,12 @@
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-      "dev": true
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
     },
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assertion-error": {
       "version": "1.1.0",
@@ -402,11 +413,15 @@
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
     },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "2.1.1",
@@ -417,14 +432,12 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
-      "dev": true
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -533,7 +546,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "dev": true,
       "optional": true,
       "requires": {
         "tweetnacl": "0.14.5"
@@ -567,6 +579,38 @@
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
       "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+    },
+    "body-parser": {
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+      "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
+      "requires": {
+        "bytes": "3.0.0",
+        "content-type": "1.0.4",
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.23",
+        "on-finished": "2.3.0",
+        "qs": "6.5.2",
+        "raw-body": "2.3.3",
+        "type-is": "1.6.16"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
     },
     "boxen": {
       "version": "1.3.0",
@@ -745,6 +789,11 @@
       "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==",
       "dev": true
     },
+    "buffer-to-arraybuffer": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
+      "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo="
+    },
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
@@ -755,6 +804,11 @@
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
+    },
+    "bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "cache-base": {
       "version": "1.0.1",
@@ -782,8 +836,7 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chai": {
       "version": "4.1.2",
@@ -931,8 +984,7 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -995,7 +1047,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-      "dev": true,
       "requires": {
         "delayed-stream": "1.0.0"
       }
@@ -1055,6 +1106,26 @@
         "xdg-basedir": "3.0.0"
       }
     },
+    "content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
+    "cookie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
@@ -1069,8 +1140,16 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cors": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
+      "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
+      "requires": {
+        "object-assign": "4.1.1",
+        "vary": "1.1.2"
+      }
     },
     "cosmiconfig": {
       "version": "5.0.5",
@@ -1190,7 +1269,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
       }
@@ -1205,7 +1283,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
       "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
-      "dev": true,
       "requires": {
         "ms": "0.7.2"
       }
@@ -1219,8 +1296,15 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+    },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "requires": {
+        "mimic-response": "1.0.1"
+      }
     },
     "dedent": {
       "version": "0.7.0",
@@ -1304,14 +1388,28 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "diff": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
       "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
       "dev": true
+    },
+    "dom-walk": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
+      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
     },
     "dot-prop": {
       "version": "4.2.0",
@@ -1351,11 +1449,15 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "dev": true,
       "optional": true,
       "requires": {
         "jsbn": "0.1.1"
       }
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -1377,6 +1479,11 @@
         "minimalistic-crypto-utils": "1.0.1"
       }
     },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
     "error-ex": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
@@ -1390,6 +1497,11 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
       "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -1408,6 +1520,25 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "eth-lib": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
+      "integrity": "sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA==",
+      "requires": {
+        "bn.js": "4.11.8",
+        "elliptic": "6.4.0",
+        "keccakjs": "0.2.1",
+        "nano-json-stream-parser": "0.1.2",
+        "servify": "0.1.12",
+        "ws": "3.3.3",
+        "xhr-request-promise": "0.1.2"
+      }
     },
     "ethereum-common": {
       "version": "0.0.18",
@@ -1462,6 +1593,22 @@
             "rlp": "2.0.0",
             "secp256k1": "3.5.0"
           }
+        }
+      }
+    },
+    "ethjs-unit": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
+      "integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
+      "requires": {
+        "bn.js": "4.11.6",
+        "number-to-bn": "1.7.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
         }
       }
     },
@@ -1539,11 +1686,133 @@
         }
       }
     },
+    "express": {
+      "version": "4.16.3",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
+      "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
+      "requires": {
+        "accepts": "1.3.5",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
+        "content-disposition": "0.5.2",
+        "content-type": "1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "finalhandler": "1.1.1",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "2.0.3",
+        "qs": "6.5.1",
+        "range-parser": "1.2.0",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.2",
+        "serve-static": "1.13.2",
+        "setprototypeof": "1.1.0",
+        "statuses": "1.4.0",
+        "type-is": "1.6.16",
+        "utils-merge": "1.0.1",
+        "vary": "1.1.2"
+      },
+      "dependencies": {
+        "body-parser": {
+          "version": "1.18.2",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+          "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+          "requires": {
+            "bytes": "3.0.0",
+            "content-type": "1.0.4",
+            "debug": "2.6.9",
+            "depd": "1.1.2",
+            "http-errors": "1.6.3",
+            "iconv-lite": "0.4.19",
+            "on-finished": "2.3.0",
+            "qs": "6.5.1",
+            "raw-body": "2.3.2",
+            "type-is": "1.6.16"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.19",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+        },
+        "raw-body": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+          "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+          "requires": {
+            "bytes": "3.0.0",
+            "http-errors": "1.6.2",
+            "iconv-lite": "0.4.19",
+            "unpipe": "1.0.0"
+          },
+          "dependencies": {
+            "depd": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+              "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+            },
+            "http-errors": {
+              "version": "1.6.2",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+              "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+              "requires": {
+                "depd": "1.1.1",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.0.3",
+                "statuses": "1.4.0"
+              }
+            },
+            "setprototypeof": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+              "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+            }
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+        },
+        "statuses": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+        }
+      }
+    },
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-      "dev": true
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -1634,20 +1903,17 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-      "dev": true
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "figures": {
       "version": "1.7.0",
@@ -1682,11 +1948,53 @@
         }
       }
     },
+    "finalhandler": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.4.0",
+        "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "statuses": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+        }
+      }
+    },
     "find-parent-dir": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
       "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
       "dev": true
+    },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "requires": {
+        "is-callable": "1.1.4"
+      }
     },
     "for-in": {
       "version": "1.0.2",
@@ -1697,19 +2005,22 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
-      "dev": true,
       "requires": {
         "asynckit": "0.4.0",
         "combined-stream": "1.0.6",
         "mime-types": "2.1.18"
       }
+    },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -1719,6 +2030,11 @@
       "requires": {
         "map-cache": "0.2.2"
       }
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -1775,7 +2091,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
       }
@@ -1792,6 +2107,15 @@
         "minimatch": "3.0.4",
         "once": "1.4.0",
         "path-is-absolute": "1.0.1"
+      }
+    },
+    "global": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+      "requires": {
+        "min-document": "2.19.0",
+        "process": "0.5.2"
       }
     },
     "global-dirs": {
@@ -1830,14 +2154,12 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-      "dev": true,
       "requires": {
         "ajv": "5.5.2",
         "har-schema": "2.0.0"
@@ -1948,6 +2270,17 @@
         "minimalistic-crypto-utils": "1.0.1"
       }
     },
+    "http-errors": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+      "requires": {
+        "depd": "1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": "1.5.0"
+      }
+    },
     "http-proxy-agent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-1.0.0.tgz",
@@ -1963,7 +2296,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
@@ -1998,6 +2330,14 @@
           "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
           "dev": true
         }
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "requires": {
+        "safer-buffer": "2.1.2"
       }
     },
     "import-lazy": {
@@ -2057,6 +2397,11 @@
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "dev": true
     },
+    "ipaddr.js": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
+      "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
+    },
     "is-absolute": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
@@ -2106,6 +2451,11 @@
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
     },
     "is-ci": {
       "version": "1.1.0",
@@ -2190,6 +2540,11 @@
       "requires": {
         "number-is-nan": "1.0.1"
       }
+    },
+    "is-function": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
     },
     "is-glob": {
       "version": "4.0.0",
@@ -2339,8 +2694,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-unc-path": {
       "version": "0.1.2",
@@ -2372,8 +2726,7 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "istanbul-lib-coverage": {
       "version": "2.0.1",
@@ -2484,7 +2837,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true,
       "optional": true
     },
     "jsesc": {
@@ -2502,20 +2854,17 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-      "dev": true
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "jspm-config": {
       "version": "0.3.4",
@@ -2546,7 +2895,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -2986,6 +3334,11 @@
         "inherits": "2.0.3"
       }
     },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
     "mem": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
@@ -2994,6 +3347,16 @@
       "requires": {
         "mimic-fn": "1.2.0"
       }
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "micromatch": {
       "version": "3.1.10",
@@ -3016,17 +3379,20 @@
         "to-regex": "3.0.2"
       }
     },
+    "mime": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+    },
     "mime-db": {
       "version": "1.33.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
-      "dev": true
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
     },
     "mime-types": {
       "version": "2.1.18",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
-      "dev": true,
       "requires": {
         "mime-db": "1.33.0"
       }
@@ -3036,6 +3402,19 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
+    },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+    },
+    "min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "requires": {
+        "dom-walk": "0.1.1"
+      }
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -3399,13 +3778,17 @@
     "ms": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-      "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-      "dev": true
+      "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
     },
     "nan": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
       "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+    },
+    "nano-json-stream-parser": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
+      "integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18="
     },
     "nanomatch": {
       "version": "1.2.9",
@@ -3426,6 +3809,11 @@
         "snapdragon": "0.8.2",
         "to-regex": "3.0.2"
       }
+    },
+    "negotiator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
     "nice-try": {
       "version": "1.0.4",
@@ -3467,6 +3855,22 @@
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
+    },
+    "number-to-bn": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
+      "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+      "requires": {
+        "bn.js": "4.11.6",
+        "strip-hex-prefix": "1.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        }
+      }
     },
     "nyc": {
       "version": "12.0.2",
@@ -5524,14 +5928,12 @@
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-      "dev": true
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
     },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -5582,11 +5984,18 @@
         "isobject": "3.0.1"
       }
     },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -5678,6 +6087,15 @@
         }
       }
     },
+    "parse-headers": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
+      "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
+      "requires": {
+        "for-each": "0.3.3",
+        "trim": "0.0.1"
+      }
+    },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -5686,6 +6104,11 @@
       "requires": {
         "error-ex": "1.3.1"
       }
+    },
+    "parseurl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
     },
     "pascalcase": {
       "version": "0.1.1",
@@ -5717,6 +6140,11 @@
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
     "pathval": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
@@ -5738,8 +6166,7 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pify": {
       "version": "3.0.0",
@@ -5845,6 +6272,11 @@
         }
       }
     },
+    "process": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
+    },
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
@@ -5857,6 +6289,15 @@
       "integrity": "sha1-3dXQ+JVDKxIGzrjaEnUGTRjnqiM=",
       "dev": true
     },
+    "proxy-addr": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
+      "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
+      "requires": {
+        "forwarded": "0.1.2",
+        "ipaddr.js": "1.6.0"
+      }
+    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -5866,14 +6307,43 @@
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-      "dev": true
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "dev": true
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "query-string": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+      "requires": {
+        "decode-uri-component": "0.2.0",
+        "object-assign": "4.1.1",
+        "strict-uri-encode": "1.1.0"
+      }
+    },
+    "randomhex": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/randomhex/-/randomhex-0.1.5.tgz",
+      "integrity": "sha1-us7vmCMpCRQA8qKRLGzQLxCU9YU="
+    },
+    "range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+    },
+    "raw-body": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+      "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+      "requires": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.23",
+        "unpipe": "1.0.0"
+      }
     },
     "rc": {
       "version": "1.2.8",
@@ -5986,7 +6456,6 @@
       "version": "2.87.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
       "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
-      "dev": true,
       "requires": {
         "aws-sign2": "0.7.0",
         "aws4": "1.7.0",
@@ -6013,8 +6482,7 @@
         "uuid": {
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-          "dev": true
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         }
       }
     },
@@ -6110,8 +6578,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "scrypt": {
       "version": "6.0.3",
@@ -6174,6 +6641,69 @@
         "semver": "5.4.1"
       }
     },
+    "send": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "1.6.3",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.4.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "statuses": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+      "requires": {
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
+        "send": "0.16.2"
+      }
+    },
+    "servify": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/servify/-/servify-0.1.12.tgz",
+      "integrity": "sha512-/xE6GvsKKqyo1BAY+KxOWXcLpPsUUyji7Qg3bVD7hh1eRze5bR1uYiuDA/k3Gof1s9BTzQZEJK8sNcNGFIzeWw==",
+      "requires": {
+        "body-parser": "1.18.3",
+        "cors": "2.8.4",
+        "express": "4.16.3",
+        "request": "2.87.0",
+        "xhr": "2.5.0"
+      }
+    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -6202,6 +6732,11 @@
           }
         }
       }
+    },
+    "setprototypeof": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
     "sha.js": {
       "version": "2.4.11",
@@ -6240,6 +6775,21 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "simple-concat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
+    },
+    "simple-get": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
+      "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
+      "requires": {
+        "decompress-response": "3.3.0",
+        "once": "1.4.0",
+        "simple-concat": "1.0.0"
+      }
     },
     "slice-ansi": {
       "version": "1.0.0",
@@ -6436,7 +6986,6 @@
       "version": "1.14.2",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
-      "dev": true,
       "requires": {
         "asn1": "0.2.3",
         "assert-plus": "1.0.0",
@@ -6475,6 +7024,16 @@
           }
         }
       }
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
     "string-argv": {
       "version": "0.0.2",
@@ -6604,8 +7163,7 @@
     "timed-out": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-      "dev": true
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
     },
     "to-fast-properties": {
       "version": "2.0.0",
@@ -6679,10 +7237,14 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-      "dev": true,
       "requires": {
         "punycode": "1.4.1"
       }
+    },
+    "trim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
     },
     "trim-right": {
       "version": "1.0.1",
@@ -6827,7 +7389,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
       "requires": {
         "safe-buffer": "5.1.2"
       }
@@ -6836,7 +7397,6 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true,
       "optional": true
     },
     "type-detect": {
@@ -6845,11 +7405,28 @@
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
+    "type-is": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "2.1.18"
+      }
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "requires": {
+        "is-typedarray": "1.0.0"
+      }
     },
     "typescript": {
       "version": "2.9.1",
@@ -6941,11 +7518,21 @@
         }
       }
     },
+    "ultron": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+    },
     "unc-path-regex": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
       "dev": true
+    },
+    "underscore": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
     },
     "union-value": {
       "version": "1.0.0",
@@ -6990,6 +7577,11 @@
       "requires": {
         "crypto-random-string": "1.0.0"
       }
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "unset-value": {
       "version": "1.0.0",
@@ -7113,6 +7705,11 @@
         "prepend-http": "1.0.4"
       }
     },
+    "url-set-query": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
+      "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk="
+    },
     "use": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
@@ -7133,16 +7730,25 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
     "uuid": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
       "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
     },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
@@ -7175,6 +7781,77 @@
           "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
           "dev": true
         }
+      }
+    },
+    "web3-core-helpers": {
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.34.tgz",
+      "integrity": "sha1-sWjaANPhnhVrwVriAyA91N/uLQM=",
+      "requires": {
+        "underscore": "1.8.3",
+        "web3-eth-iban": "1.0.0-beta.34",
+        "web3-utils": "1.0.0-beta.34"
+      }
+    },
+    "web3-eth-iban": {
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.34.tgz",
+      "integrity": "sha1-mvRYYFhnzPdOqXmq8yazi6alugw=",
+      "requires": {
+        "bn.js": "4.11.6",
+        "web3-utils": "1.0.0-beta.34"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        }
+      }
+    },
+    "web3-providers-ws": {
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.34.tgz",
+      "integrity": "sha1-fecPG4Py3jZHZ3IVa+z+9uNRbrM=",
+      "requires": {
+        "underscore": "1.8.3",
+        "web3-core-helpers": "1.0.0-beta.34",
+        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+      }
+    },
+    "web3-utils": {
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.34.tgz",
+      "integrity": "sha1-lBH8OarvOcpOBhafdiKX2f8CCXA=",
+      "requires": {
+        "bn.js": "4.11.6",
+        "eth-lib": "0.1.27",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randomhex": "0.1.5",
+        "underscore": "1.8.3",
+        "utf8": "2.1.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        },
+        "utf8": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
+          "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g="
+        }
+      }
+    },
+    "websocket": {
+      "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+      "requires": {
+        "debug": "2.6.0",
+        "nan": "2.10.0",
+        "typedarray-to-buffer": "3.1.5",
+        "yaeti": "0.0.6"
       }
     },
     "which": {
@@ -7247,8 +7924,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
       "version": "2.3.0",
@@ -7261,11 +7937,54 @@
         "signal-exit": "3.0.2"
       }
     },
+    "ws": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+      "requires": {
+        "async-limiter": "1.0.0",
+        "safe-buffer": "5.1.2",
+        "ultron": "1.1.1"
+      }
+    },
     "xdg-basedir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
       "dev": true
+    },
+    "xhr": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
+      "integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
+      "requires": {
+        "global": "4.3.2",
+        "is-function": "1.0.1",
+        "parse-headers": "2.0.1",
+        "xtend": "4.0.1"
+      }
+    },
+    "xhr-request": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
+      "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
+      "requires": {
+        "buffer-to-arraybuffer": "0.0.5",
+        "object-assign": "4.1.1",
+        "query-string": "5.1.1",
+        "simple-get": "2.8.1",
+        "timed-out": "4.0.1",
+        "url-set-query": "1.0.0",
+        "xhr": "2.5.0"
+      }
+    },
+    "xhr-request-promise": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.2.tgz",
+      "integrity": "sha1-NDxE0e53JrhkgGloLQ+EDIO0Jh0=",
+      "requires": {
+        "xhr-request": "1.1.0"
+      }
     },
     "xhr2": {
       "version": "0.1.4",
@@ -7282,14 +8001,18 @@
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "y18n": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
       "dev": true
+    },
+    "yaeti": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
     },
     "yallist": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "ethereumjs-tx": "1.3.6",
     "ethereumjs-wallet": "0.6.0",
     "lokijs": "1.5.5",
-    "typescript": "2.9.1"
+    "typescript": "2.9.1",
+    "web3-providers-ws": "1.0.0-beta.34"
   },
   "devDependencies": {
     "@types/bluebird": "3.5.22",

--- a/src/Actions/Pending.ts
+++ b/src/Actions/Pending.ts
@@ -26,7 +26,7 @@ const hasPendingParity = async (
         id: 0o7
       },
       async (err: Error, res: any) => {
-        if (err !== null || res.hasOwnProperty('error')) {
+        if (err) {
           reject(err);
         }
 
@@ -73,7 +73,7 @@ const hasPendingGeth = (
         id: 0o7
       },
       async (err: Error, res: any) => {
-        if (err !== null || res.hasOwnProperty('error')) {
+        if (err) {
           reject(err);
         }
 
@@ -165,8 +165,6 @@ const hasPending = (
   if (conf.client === 'geth') {
     return hasPendingGeth(conf, txRequest, opts);
   }
-
-  return true;
 };
 
 export default hasPending;

--- a/src/Actions/Pending.ts
+++ b/src/Actions/Pending.ts
@@ -26,7 +26,7 @@ const hasPendingParity = async (
         id: 0o7
       },
       async (err: Error, res: any) => {
-        if (err) {
+        if (err !== null || res.hasOwnProperty('error')) {
           reject(err);
         }
 
@@ -73,7 +73,7 @@ const hasPendingGeth = (
         id: 0o7
       },
       async (err: Error, res: any) => {
-        if (err) {
+        if (err !== null || res.hasOwnProperty('error')) {
           reject(err);
         }
 
@@ -165,6 +165,8 @@ const hasPending = (
   if (conf.client === 'geth') {
     return hasPendingGeth(conf, txRequest, opts);
   }
+
+  return true;
 };
 
 export default hasPending;

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -1,3 +1,4 @@
+import * as Web3 from 'web3';
 import Cache from '../Cache';
 import Wallet from '../Wallet';
 import { IConfigParams } from './IConfigParams';
@@ -5,6 +6,7 @@ import { IEconomicStrategy } from '../EconomicStrategy';
 import { ILogger, DefaultLogger } from '../Logger';
 import { StatsDB } from '../Stats';
 import W3Util from '../Util';
+import { getWeb3FromProviderUrl } from './helpers';
 
 export default class Config implements IConfigParams {
   public autostart: boolean;
@@ -13,10 +15,9 @@ export default class Config implements IConfigParams {
   public client?: string;
   public eac: any;
   public economicStrategy?: IEconomicStrategy;
-  public factory: any;
   public logger?: ILogger;
   public ms: any;
-  public provider: any;
+  public providerUrl: string;
   public scanSpread: any;
   public statsDb: StatsDB;
   public util: any;
@@ -25,27 +26,22 @@ export default class Config implements IConfigParams {
   public walletStoresAsPrivateKeys: boolean;
 
   constructor(params: IConfigParams) {
-    this.autostart = params.autostart || true;
+    if (params.providerUrl) {
+      this.web3 = getWeb3FromProviderUrl(params.providerUrl);
+      this.eac = require('eac.js-lib')(this.web3);
+    } else {
+      throw new Error('Please set the providerUrl in the config object.');
+    }
+
+    this.autostart = params.autostart !== undefined ? params.autostart : true;
     this.claiming = params.claiming || false;
     this.ms = params.ms || 4000;
     this.scanSpread = params.scanSpread || 50;
-    this.walletStoresAsPrivateKeys = params.walletStoresAsPrivateKeys;
-    this.client = params.client;
-
+    this.walletStoresAsPrivateKeys = params.walletStoresAsPrivateKeys || false;
+    this.client = params.client || null;
     this.logger = params.logger || new DefaultLogger();
 
     this.cache = new Cache(this.logger);
-
-    if (params.eac && params.factory && params.provider && params.web3) {
-      this.eac = params.eac;
-      this.factory = params.factory;
-      this.provider = params.provider;
-      this.web3 = params.web3;
-    } else {
-      throw new Error(
-        'Passed in Config params are incomplete! Unable to start TimeNode. Quitting..'
-      );
-    }
 
     if (params.walletStores && params.walletStores.length && params.walletStores.length > 0) {
       this.wallet = new Wallet(this.web3, this.logger);
@@ -61,13 +57,20 @@ export default class Config implements IConfigParams {
       if (this.walletStoresAsPrivateKeys) {
         this.wallet.loadPrivateKeys(params.walletStores);
       } else {
-        this.wallet.decrypt(params.walletStores, params.password);
+        if (params.password) {
+          this.wallet.decrypt(params.walletStores, params.password);
+        } else {
+          throw new Error(
+            'Unable to unlock the wallet. Please provide a password as a config param'
+          );
+        }
       }
     } else {
       this.wallet = null;
     }
 
-    this.statsDb = params.statsDb;
+    this.statsDb = params.statsDb ? new StatsDB(this.web3, params.statsDb) : null;
+
     this.util = new W3Util(this.web3);
     this.economicStrategy = params.economicStrategy;
   }

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -1,4 +1,3 @@
-import * as Web3 from 'web3';
 import Cache from '../Cache';
 import Wallet from '../Wallet';
 import { IConfigParams } from './IConfigParams';

--- a/src/Config/IConfigParams.ts
+++ b/src/Config/IConfigParams.ts
@@ -1,22 +1,17 @@
 import { IEconomicStrategy } from '../EconomicStrategy';
-import { ILogger, DefaultLogger } from '../Logger';
-import { StatsDB } from '../Stats';
+import { ILogger } from '../Logger';
 
-//TODO remove factory
 export interface IConfigParams {
-  autostart: boolean;
+  autostart?: boolean;
   client?: string;
   claiming?: boolean;
-  eac: any;
   economicStrategy?: IEconomicStrategy;
-  factory?: any;
   logger?: ILogger | null;
   ms?: any;
   password?: any;
-  provider: any;
-  scanSpread: number | null;
-  statsDb: StatsDB;
+  providerUrl: string;
+  scanSpread?: number | null;
+  statsDb?: any;
   walletStores?: any;
-  web3: any;
-  walletStoresAsPrivateKeys: boolean;
+  walletStoresAsPrivateKeys?: boolean;
 }

--- a/src/Config/helpers.ts
+++ b/src/Config/helpers.ts
@@ -1,0 +1,18 @@
+import * as Web3 from 'web3';
+import Web3WsProvider from 'web3-providers-ws';
+
+const getWeb3FromProviderUrl = (providerUrl: string) => {
+  const provider = (() => {
+    if (new RegExp('http://').test(providerUrl) || new RegExp('https://').test(providerUrl)) {
+      return new Web3.providers.HttpProvider(`${providerUrl}`);
+    } else if (new RegExp('ws://').test(providerUrl) || new RegExp('wss://').test(providerUrl)) {
+      const ws = new Web3WsProvider(`${providerUrl}`);
+      ws.__proto__.sendAsync = ws.__proto__.send;
+      return ws;
+    }
+  })();
+
+  return new Web3(provider);
+};
+
+export { getWeb3FromProviderUrl };

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,3 +1,4 @@
 declare module 'ethereumjs-wallet';
 declare module 'web3';
 declare module 'eac.js-lib';
+declare module 'web3-providers-ws';

--- a/test/e2e/TestScheduleTx.ts
+++ b/test/e2e/TestScheduleTx.ts
@@ -4,13 +4,12 @@ import * as Web3 from 'web3';
 import BigNumber from 'bignumber.js';
 import { expect } from 'chai';
 import { calcEndowment, providerUrl } from '../helpers';
-// import { createWallet } from './helpers';
 
 const CLAIM_WINDOW_SIZE = 255;
 
 export const getHelperMethods = (web3: any) => {
   function sendRpc(method: any, params?: any) {
-    return new Promise(function(resolve) {
+    return new Promise(resolve => {
       web3.currentProvider.sendAsync(
         {
           jsonrpc: '2.0',
@@ -18,7 +17,7 @@ export const getHelperMethods = (web3: any) => {
           params: params || [],
           id: new Date().getTime()
         },
-        function(err: any, res: any) {
+        (err: any, res: any) => {
           resolve(res);
         }
       );
@@ -26,16 +25,14 @@ export const getHelperMethods = (web3: any) => {
   }
 
   function waitUntilBlock(seconds: any, targetBlock: any) {
-    return new Promise(function(resolve) {
-      let asyncIterator = function asyncIterator() {
-        return web3.eth.getBlock('latest', function(e: any, _ref: any) {
-          let number = _ref.number;
+    return new Promise(resolve => {
+      const asyncIterator = function asyncIterator() {
+        return web3.eth.getBlock('latest', (e: any, _ref: any) => {
+          const num = _ref.number;
 
-          if (number >= targetBlock - 1) {
+          if (num >= targetBlock - 1) {
             return sendRpc('evm_increaseTime', [seconds])
-              .then(function() {
-                return sendRpc('evm_mine');
-              })
+              .then(() => sendRpc('evm_mine'))
               .then(resolve);
           }
           return sendRpc('evm_mine').then(asyncIterator);

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -1,5 +1,5 @@
 export { MockTxRequest, mockTxStatus } from './MockTxRequest';
-export { mockConfig } from './mockConfig';
+export { mockConfig, PRIVATE_KEY } from './mockConfig';
 export { createWallet, createWalletKeystore } from './createWallet';
 export { providerUrl } from './network';
 export { calcEndowment } from './calcEndowment';

--- a/test/helpers/mockConfig.ts
+++ b/test/helpers/mockConfig.ts
@@ -1,52 +1,41 @@
-import * as Web3 from 'web3';
 import * as loki from 'lokijs';
-import { Config, StatsDB } from '../../src/index';
+import { Config } from '../../src/index';
 import MockLogger from './MockLogger';
 import { createWalletKeystore } from './createWallet';
 import { providerUrl } from './network';
 import BigNumber from 'bignumber.js';
 
+const PRIVATE_KEY = 'fdf2e15fd858d9d81e31baa1fe76de9c7d49af0018a1322aa2b9e493b02afa26';
+
 const mockConfig = (preConfig?: any) => {
-  const provider =
-    preConfig && preConfig.provider
-      ? preConfig.provider
-      : new Web3.providers.HttpProvider(providerUrl);
-  const web3 = preConfig && preConfig.web3 ? preConfig.web3 : new Web3(provider);
-  const eac = preConfig && preConfig.eac ? preConfig.eac : require('eac.js-lib')(web3);
   const client = preConfig && preConfig.client ? preConfig.client : undefined;
 
   const filename = 'wallet.txt';
   const password = 'password123';
-  const wallet = ['fdf2e15fd858d9d81e31baa1fe76de9c7d49af0018a1322aa2b9e493b02afa26']; //createWalletKeystore(web3, 1, filename, password);
+  const wallet = [PRIVATE_KEY]; //createWalletKeystore(web3, 1, filename, password);
 
   return new Config({
     autostart: true,
     client,
     claiming: true,
-    eac,
     economicStrategy: {
       maxDeposit: new BigNumber(0),
       minBalance: new BigNumber(0),
       minProfitability: new BigNumber(0)
     },
-    factory: '0x0',
     logger: new MockLogger(),
     ms: 4000,
     password,
-    provider,
+    providerUrl,
     scanSpread: 0,
-    statsDb: new StatsDB(
-      web3,
-      new loki('stats.db', {
-        autoload: true,
-        autosave: true,
-        autosaveInterval: 4000
-      })
-    ),
+    statsDb: new loki('stats.db', {
+      autoload: true,
+      autosave: true,
+      autosaveInterval: 4000
+    }),
     walletStores: wallet,
-    walletStoresAsPrivateKeys: true,
-    web3
+    walletStoresAsPrivateKeys: true
   });
 };
 
-export { mockConfig };
+export { mockConfig, PRIVATE_KEY };

--- a/test/helpers/mockConfig.ts
+++ b/test/helpers/mockConfig.ts
@@ -1,7 +1,7 @@
 import * as loki from 'lokijs';
 import { Config } from '../../src/index';
 import MockLogger from './MockLogger';
-import { createWalletKeystore } from './createWallet';
+// import { createWalletKeystore } from './createWallet';
 import { providerUrl } from './network';
 import BigNumber from 'bignumber.js';
 

--- a/test/unit/UnitTestCache.ts
+++ b/test/unit/UnitTestCache.ts
@@ -1,37 +1,71 @@
-import { expect } from 'chai';
+import { expect, assert } from 'chai';
 import Cache from '../../src/Cache';
 import { DefaultLogger } from '../../src/Logger';
 
-if (process.env.RUN_ONLY_OPTIONAL_TESTS !== 'true') {
-  describe('Cache', () => {
-    let cache: Cache;
-    beforeEach(() => {
-      cache = new Cache(new DefaultLogger());
-    })
+describe('Cache unit tests', () => {
+  let cache: Cache;
+  beforeEach(() => {
+    cache = new Cache(new DefaultLogger());
+  });
 
-    it('stores and reads the key,value', () => {
-      cache.set("key", "value");
-
-      const result = cache.get("key");
-      expect(result).to.equals("value");
+  describe('get()', () => {
+    it('get the key value', () => {
+      cache.set('key', 'value');
+      const result = cache.get('key');
+      expect(result).to.equals('value');
     });
 
-    it('return proper length', () => {
-      cache.set("key", "value");
+    it('throws an error if value is undefined', () => {
+      cache.set('key', undefined);
+      expect(() => cache.get('key')).to.throw();
+    });
 
-      const result = cache.len()
+    it('returns `d` if value and `d` is undefined', () => {
+      cache.set('key', undefined);
+      const d = () => console.log('callback');
+      const result = cache.get('key', d);
+      assert.equal(result, d);
+    });
+  });
+
+  describe('len()', () => {
+    it('return proper length', () => {
+      cache.set('key', 'value');
+      const result = cache.len();
       expect(result).to.equals(1);
     });
+  });
 
+  describe('stored()', () => {
     it('returns stored values', () => {
-      cache.set("key", "value");
-      cache.set("key2", "value2");
+      cache.set('key', 'value');
+      cache.set('key2', 'value2');
 
       const results = cache.stored();
 
       expect(results.length).to.equals(2);
-      expect(results[0]).to.equals("key");
-      expect(results[1]).to.equals("key2");
+      expect(results[0]).to.equals('key');
+      expect(results[1]).to.equals('key2');
     });
-  })
-}
+  });
+
+  describe('del()', () => {
+    it('returns stored values', () => {
+      const key = 'key';
+      cache.set(key, 'value');
+      cache.del(key);
+      expect(() => cache.get(key)).to.throw();
+    });
+  });
+
+  describe('has()', () => {
+    it('returns true when value is in cache', () => {
+      cache.set('key', 'value');
+      assert.isTrue(cache.has('key'));
+    });
+
+    it('returns false when value is not in cache', () => {
+      assert.isFalse(cache.has('key'));
+    });
+  });
+});

--- a/test/unit/UnitTestConfig.ts
+++ b/test/unit/UnitTestConfig.ts
@@ -1,0 +1,81 @@
+import { expect, assert } from 'chai';
+import Config from '../../src/Config';
+import { DefaultLogger } from '../../src/Logger';
+import { PRIVATE_KEY, providerUrl } from '../helpers';
+
+const WALLET_PASSWD = 'Wak9bk7DwZYL';
+const WALLET_KEYSTORE = `{"version":3,"id":"90ff6d22-668b-492a-bc56-8b560fece46d","address":"487a54e1d033db51c8ee8c03edac2a0f8a6892c6","crypto":{"ciphertext":"115c232498a4f47d10de6c7148b8ebefdac44581b74475bba51675e83d7244dd","cipherparams":{"iv":"b53497a50161315e3fe4f33a9b74c22b"},"cipher":"aes-128-ctr","kdf":"scrypt","kdfparams":{"dklen":32,"salt":"6d6e0329bf255c65c64e9e2face95227ab3221e8648635ac1b65a3c78ce25bbc","n":8192,"r":8,"p":1},"mac":"d771499de6091c8947f8ee9e5e91c3ea9b0b08ed90844c34f77ae2e33b40f40e"}}`;
+
+describe('Config unit tests', () => {
+  describe('constructor()', () => {
+    it('throws an error when initiating without required params', () => {
+      expect(() => new Config({ providerUrl: null })).to.throw();
+    });
+
+    it('check all default values are set when empty config', () => {
+      const config = new Config({ providerUrl });
+
+      assert.isTrue(config.autostart);
+      assert.isFalse(config.claiming);
+      assert.equal(config.ms, 4000);
+      assert.equal(config.scanSpread, 50);
+      assert.isFalse(config.walletStoresAsPrivateKeys);
+      assert.isNull(config.client);
+      expect(config.logger).to.exist;
+      assert.isNull(config.wallet);
+    });
+
+    it('check all values are set when added to config object', () => {
+      const config = new Config({
+        providerUrl,
+        autostart: false,
+        claiming: true,
+        ms: 10000,
+        scanSpread: 100,
+        walletStoresAsPrivateKeys: true,
+        client: 'parity',
+        logger: new DefaultLogger(),
+        walletStores: [PRIVATE_KEY]
+      });
+
+      assert.isFalse(config.autostart);
+      assert.isTrue(config.claiming);
+      assert.equal(config.ms, 10000);
+      assert.equal(config.scanSpread, 100);
+      assert.isTrue(config.walletStoresAsPrivateKeys);
+      assert.isNotNull(config.client);
+      expect(config.logger).to.exist;
+      assert.equal(config.wallet.length, 1);
+    });
+
+    it('wallet decrypted when using a keystore string', () => {
+      const config = new Config({
+        providerUrl,
+        walletStores: [WALLET_KEYSTORE],
+        password: WALLET_PASSWD
+      });
+
+      assert.equal(config.wallet.length, 1);
+    });
+
+    it('wallet decrypted when using a keystore object', () => {
+      const config = new Config({
+        providerUrl,
+        walletStores: [JSON.parse(WALLET_KEYSTORE)],
+        password: WALLET_PASSWD
+      });
+
+      assert.equal(config.wallet.length, 1);
+    });
+
+    it('throws an error when using a keystore without a password', () => {
+      expect(
+        () =>
+          new Config({
+            providerUrl,
+            walletStores: [WALLET_KEYSTORE]
+          })
+      ).to.throw();
+    });
+  });
+});

--- a/test/unit/UnitTestPending.ts
+++ b/test/unit/UnitTestPending.ts
@@ -57,27 +57,24 @@ const pendingTx = (opts?: any) => {
   return { result, client: opts.client };
 };
 
-const preConfig = (opt?: any) =>
-  Object.assign(
-    {},
-    {
-      provider: opt.provider ? opt.provider : new provider(),
-      web3: {
-        currentProvider: opt.provider ? opt.provider : new provider(),
-        eth: {
-          getGasPrice: async (callback?: any) => {
-            const gasPrice = opt.netGasPrice ? opt.netGasPrice : opt.gasPrice;
-            if (callback) {
-              callback(null, gasPrice);
-            }
-            return gasPrice;
-          }
+const preConfig = (config: Config, opt?: any) => {
+  config.web3 = {
+    currentProvider: opt.provider ? opt.provider : new provider(),
+    eth: {
+      getGasPrice: async (callback?: any) => {
+        const gasPrice = opt.netGasPrice ? opt.netGasPrice : opt.gasPrice;
+        if (callback) {
+          callback(null, gasPrice);
         }
-      },
-      eac: {}
-    },
-    opt
-  );
+        return gasPrice;
+      }
+    }
+  };
+
+  config.client = opt.client;
+
+  return config;
+};
 
 const mockTx = (opts: any) => {
   return {
@@ -112,14 +109,14 @@ const randomClient = () => CLIENTS[Math.floor(Math.random() * CLIENTS.length)];
 describe('Pending Unit Tests', () => {
   it('Detects valid Pending requests (parity)', async () => {
     const gasPrice = 1 * 1e12;
-    const config = mockConfig(preConfig({ client: 'parity', gasPrice }));
+    const config = preConfig(mockConfig(), { client: 'parity', gasPrice });
     const pending = await hasPending(config, mockTx({ address: startAddr, gasPrice }), {});
     expect(pending).to.be.true;
   });
 
   it('Detects valid Pending requests (geth)', async () => {
     const gasPrice = 1 * 1e12;
-    const config = mockConfig(preConfig({ client: 'geth', gasPrice }));
+    const config = preConfig(mockConfig(), { client: 'geth', gasPrice });
     const pending = await hasPending(config, mockTx({ address: startAddr, gasPrice }), {});
     expect(pending).to.be.true;
   });
@@ -129,13 +126,11 @@ describe('Pending Unit Tests', () => {
     const results: any = [];
     const gasPrice = 1 * 1e12;
     const testConfigs: Config[] = CLIENTS.map(client =>
-      mockConfig(
-        preConfig({
-          client,
-          gasPrice,
-          provider: new provider({ input: FnSignatures.claim })
-        })
-      )
+      preConfig(mockConfig(), {
+        client,
+        gasPrice,
+        provider: new provider({ input: FnSignatures.claim })
+      })
     );
     await Promise.all(
       testConfigs.map(async conf => {
@@ -153,13 +148,11 @@ describe('Pending Unit Tests', () => {
     const results: any = [];
     const gasPrice = 1 * 1e12;
     const testConfigs: Config[] = CLIENTS.map(client =>
-      mockConfig(
-        preConfig({
-          client,
-          gasPrice,
-          provider: new provider({ input: FnSignatures.execute })
-        })
-      )
+      preConfig(mockConfig(), {
+        client,
+        gasPrice,
+        provider: new provider({ input: FnSignatures.execute })
+      })
     );
     await Promise.all(
       testConfigs.map(async conf => {
@@ -177,14 +170,12 @@ describe('Pending Unit Tests', () => {
     const results: any = [];
     const gasPrice = 1 * 1e12;
     const testConfigs: Config[] = CLIENTS.map(client =>
-      mockConfig(
-        preConfig({
-          client,
-          gasPrice,
-          netGasPrice: 15 * 1e13,
-          provider: new provider({ input: FnSignatures.claim })
-        })
-      )
+      preConfig(mockConfig(), {
+        client,
+        gasPrice,
+        netGasPrice: 15 * 1e13,
+        provider: new provider({ input: FnSignatures.claim })
+      })
     );
     await Promise.all(
       testConfigs.map(async conf => {
@@ -202,13 +193,11 @@ describe('Pending Unit Tests', () => {
     const results: any = [];
     const gasPrice = 1 * 1e12;
     const testConfigs: Config[] = CLIENTS.map(client =>
-      mockConfig(
-        preConfig({
-          client,
-          gasPrice,
-          provider: new provider({ input: FnSignatures.execute })
-        })
-      )
+      preConfig(mockConfig(), {
+        client,
+        gasPrice,
+        provider: new provider({ input: FnSignatures.execute })
+      })
     );
     await Promise.all(
       testConfigs.map(async conf => {
@@ -226,13 +215,11 @@ describe('Pending Unit Tests', () => {
     const results: any = [];
     const gasPrice = 1 * 1e12;
     const testConfigs: Config[] = CLIENTS.map(client =>
-      mockConfig(
-        preConfig({
-          client,
-          gasPrice,
-          provider: new provider({ input: FnSignatures.claim })
-        })
-      )
+      preConfig(mockConfig(), {
+        client,
+        gasPrice,
+        provider: new provider({ input: FnSignatures.claim })
+      })
     );
     await Promise.all(
       testConfigs.map(async conf => {
@@ -251,13 +238,11 @@ describe('Pending Unit Tests', () => {
     const gasPrice = 1 * 1e12;
     const exactPrice = 0.9 * 1e12;
     const testConfigs: Config[] = CLIENTS.map(client =>
-      mockConfig(
-        preConfig({
-          client,
-          gasPrice,
-          provider: new provider({ input: FnSignatures.execute })
-        })
-      )
+      preConfig(mockConfig(), {
+        client,
+        gasPrice,
+        provider: new provider({ input: FnSignatures.execute })
+      })
     );
     await Promise.all(
       testConfigs.map(async conf => {

--- a/test/unit/UnitTestScanner.ts
+++ b/test/unit/UnitTestScanner.ts
@@ -46,7 +46,7 @@ describe('Scanner Unit Tests', () => {
       assert.isTrue(scanner.scanning);
       expect(scanner.cacheScanner).to.exist;
       expect(scanner.chainScanner).to.exist;
-    });
+    }).timeout(5000);
   });
 
   describe('stop()', async () => {
@@ -56,7 +56,7 @@ describe('Scanner Unit Tests', () => {
       assert.isNotTrue(scanner.scanning);
       assert.equal(scanner.cacheScanner[0], null);
       assert.equal(scanner.chainScanner[0], null);
-    });
+    }).timeout(5000);
   });
 
   describe('isUpcoming()', () => {

--- a/test/unit/UnitTestTimeNode.ts
+++ b/test/unit/UnitTestTimeNode.ts
@@ -3,22 +3,22 @@ import { TimeNode, Config } from '../../src/index';
 import { mockConfig } from '../helpers';
 
 describe('TimeNode Unit Tests', () => {
-    const config: Config = mockConfig();    
-    let timenode: TimeNode;
+  const config: Config = mockConfig();
+  let timenode: TimeNode;
 
-    it('initializes a basic timenode', () => {
-        timenode = new TimeNode(config);
-        expect(timenode).to.exist;
-    });
+  it('initializes a basic timenode', () => {
+    timenode = new TimeNode(config);
+    expect(timenode).to.exist;
+  });
 
-    it('starts scanning', async () => {
-        const result: Boolean = await timenode.startScanning();
-        expect(result).to.be.true;
-        expect(timenode.scanner.scanning).to.be.true;
-    });
+  it('starts scanning', async () => {
+    const result: Boolean = await timenode.startScanning();
+    expect(result).to.be.true;
+    expect(timenode.scanner.scanning).to.be.true;
+  }).timeout(5000);
 
-    it('stops scanning', async () => {
-        await timenode.stopScanning();
-        expect(timenode.scanner.scanning).to.be.false;
-    });
-})
+  it('stops scanning', async () => {
+    await timenode.stopScanning();
+    expect(timenode.scanner.scanning).to.be.false;
+  }).timeout(5000);
+});


### PR DESCRIPTION
**BREAKING CHANGE:**
- Refactor the Config object -  Config object no longer needs the `provider`, `web3` and `eac.js-lib` object as a parameter - This is replaced only with a `providerUrl`

TESTS:
- Add unit tests to the Config object
- Adjust all other unit tests to Config object changes
