### PR TITLE
[FEATURE] New gas price mechanism - Minimum gas price

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -187,7 +187,7 @@
       "integrity": "sha512-p0KlwRLui/Xn7/bXYzVhhYU9+Cv1I/JL/1CTHW1RXMz2GDFbQj0BGzohUHrv6p7QzugB6+Y/b0Z7Uh4G11RJqg==",
       "dev": true,
       "requires": {
-        "@types/node": "10.5.3"
+        "@types/node": "10.5.4"
       }
     },
     "@types/lokijs": {
@@ -203,9 +203,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.5.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.5.3.tgz",
-      "integrity": "sha512-jQ1p+SyF/z8ygPxfSPKZKMWazlCgTBSyIaC1UCUvkLHDdxdmPQtQFk02X4WFM31Z1BKMAS3MSAK0cRP2c92n6Q==",
+      "version": "10.5.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.5.4.tgz",
+      "integrity": "sha512-8TqvB0ReZWwtcd3LXq3YSrBoLyXFgBX/sBZfGye9+YS8zH7/g+i6QRIuiDmwBoTzcQ/pk89nZYTYU4c5akKkzw==",
       "dev": true
     },
     "abbrev": {
@@ -2342,17 +2342,6 @@
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
         "statuses": "1.5.0"
-      }
-    },
-    "http-proxy-agent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-1.0.0.tgz",
-      "integrity": "sha1-zBzjjkU7+YSg93AtLdWcc9CBKEo=",
-      "dev": true,
-      "requires": {
-        "agent-base": "2.1.1",
-        "debug": "2.6.0",
-        "extend": "3.0.1"
       }
     },
     "http-signature": {
@@ -6136,7 +6125,6 @@
       "integrity": "sha1-uRM8VdlFdZq37mG3cRNkYg066tw=",
       "dev": true,
       "requires": {
-        "http-proxy-agent": "1.0.0",
         "https-proxy-agent": "1.0.0"
       }
     },

--- a/src/Actions/Actions.ts
+++ b/src/Actions/Actions.ts
@@ -102,11 +102,7 @@ export default class Actions {
   }
 
   public async execute(txRequest: any): Promise<any> {
-    const gasToExecute = txRequest.callGas
-      .add(180000)
-      .div(64)
-      .times(65)
-      .round();
+    const gasToExecute = this.config.util.calculateGasAmount(txRequest);
     // TODO Check that the gasToExecue < gasLimit of latest block w/ some margin
 
     // TODO make this a constant

--- a/src/Actions/Actions.ts
+++ b/src/Actions/Actions.ts
@@ -116,7 +116,7 @@ export default class Actions {
     if (
       await hasPending(this.config, txRequest, {
         type: 'execute',
-        exactPrice: gasPrice
+        exactPrice: opts.gasPrice
       })
     ) {
       return ExecuteStatus.PENDING;

--- a/src/EconomicStrategy/EconomicStrategyHelpers.ts
+++ b/src/EconomicStrategy/EconomicStrategyHelpers.ts
@@ -1,6 +1,6 @@
 import { IEconomicStrategy } from './IEconomicStrategy';
 import Config from '../Config';
-import { BigNumber } from '../../node_modules/bignumber.js';
+import { BigNumber } from 'bignumber.js';
 
 /**
  * Checks whether a transaction requires a deposit that's higher than a
@@ -8,10 +8,7 @@ import { BigNumber } from '../../node_modules/bignumber.js';
  * @param {TransactionRequest} txRequest Transaction Request object to check.
  * @param {IEconomicStrategy} economicStrategy Economic strategy configuration object.
  */
-const exceedsMaxDeposit = (
-  txRequest: any,
-  economicStrategy: IEconomicStrategy
-): boolean | BigNumber => {
+const exceedsMaxDeposit = (txRequest: any, economicStrategy: IEconomicStrategy): boolean => {
   const requiredDeposit = txRequest.requiredDeposit;
   const maxDeposit = economicStrategy.maxDeposit;
 
@@ -26,7 +23,7 @@ const exceedsMaxDeposit = (
  * Checks if the balance of the TimeNode is above a set limit.
  * @param {Config} config TimeNode configuration object.
  */
-const isAboveMinBalanceLimit = async (config: Config): Promise<boolean | BigNumber> => {
+const isAboveMinBalanceLimit = async (config: Config): Promise<boolean> => {
   const minBalance = config.economicStrategy.minBalance;
   const currentBalance = await config.wallet.getBalanceOf(config.wallet.getAddresses()[0]);
 
@@ -45,7 +42,7 @@ const isAboveMinBalanceLimit = async (config: Config): Promise<boolean | BigNumb
 const isProfitable = async (
   txRequest: any,
   economicStrategy: IEconomicStrategy
-): Promise<boolean | BigNumber> => {
+): Promise<boolean> => {
   const paymentModifier = await txRequest.claimPaymentModifier();
   const reward = txRequest.bounty.times(paymentModifier);
 

--- a/src/EconomicStrategy/EconomicStrategyHelpers.ts
+++ b/src/EconomicStrategy/EconomicStrategyHelpers.ts
@@ -132,12 +132,16 @@ const shouldExecuteTx = async (txRequest: any, config: Config): Promise<boolean>
   const reward = txRequest.bounty.times(paymentModifier);
 
   const gasCost = gasPrice.times(gasAmount);
+  const expectedReward = deposit.plus(reward).plus(reimbursement);
+  const shouldExecuteTx = gasCost.lessThanOrEqualTo(expectedReward);
 
-  if (gasCost.greaterThan(deposit.plus(reward).plus(reimbursement))) {
-    return false;
-  }
+  config.logger.debug(
+    `[${
+      txRequest.address
+    }] shouldExecuteTx ret ${shouldExecuteTx} gasCost=${gasCost.toNumber()} expectedReward=${expectedReward.toNumber()}`
+  );
 
-  return true;
+  return shouldExecuteTx;
 };
 
 export { shouldClaimTx, shouldExecuteTx, getExecutionGasPrice };

--- a/src/EconomicStrategy/EconomicStrategyHelpers.ts
+++ b/src/EconomicStrategy/EconomicStrategyHelpers.ts
@@ -133,15 +133,15 @@ const shouldExecuteTx = async (txRequest: any, config: Config): Promise<boolean>
 
   const gasCost = gasPrice.times(gasAmount);
   const expectedReward = deposit.plus(reward).plus(reimbursement);
-  const shouldExecuteTx = gasCost.lessThanOrEqualTo(expectedReward);
+  const shouldExecute = gasCost.lessThanOrEqualTo(expectedReward);
 
   config.logger.debug(
     `[${
       txRequest.address
-    }] shouldExecuteTx ret ${shouldExecuteTx} gasCost=${gasCost.toNumber()} expectedReward=${expectedReward.toNumber()}`
+    }] shouldExecuteTx ret ${shouldExecute} gasCost=${gasCost.toNumber()} expectedReward=${expectedReward.toNumber()}`
   );
 
-  return shouldExecuteTx;
+  return shouldExecute;
 };
 
 export { shouldClaimTx, shouldExecuteTx, getExecutionGasPrice };

--- a/src/EconomicStrategy/IEconomicStrategy.ts
+++ b/src/EconomicStrategy/IEconomicStrategy.ts
@@ -20,7 +20,7 @@ export interface IEconomicStrategy {
   minProfitability?: BigNumber;
 
   /**
-   * A number 0-100 which defines the percentage with which
+   * A number which defines the percentage with which
    * the TimeNode would be able to subsidize the amount of gas
    * it sends at the time of the execution.
    *

--- a/src/EconomicStrategy/IEconomicStrategy.ts
+++ b/src/EconomicStrategy/IEconomicStrategy.ts
@@ -1,7 +1,32 @@
 import BigNumber from 'bignumber.js';
 
 export interface IEconomicStrategy {
+  /**
+   * Maximum deposit a TimeNode would be willing
+   * to stake while claiming a transaction.
+   */
   maxDeposit?: BigNumber;
+
+  /**
+   * Minimum balance a TimeNode has to
+   * have in order to claim a transaction.
+   */
   minBalance?: BigNumber;
+
+  /**
+   * Minimum profitability a scheduled transactions
+   * has to bring in order for the TimeNode to claim it.
+   */
   minProfitability?: BigNumber;
+
+  /**
+   * A number 0-100 which defines the percentage with which
+   * the TimeNode would be able to subsidize the amount of gas
+   * it sends at the time of the execution.
+   *
+   * e.g. If the scheduled transaction has set the gas price to 20 gwei
+   *      and `maxGasSubsidy` is set to 50, the TimeNode would be willing
+   *      to subsidize gas costs to up to 30 gwei.
+   */
+  maxGasSubsidy?: number;
 }

--- a/src/EconomicStrategy/index.ts
+++ b/src/EconomicStrategy/index.ts
@@ -1,2 +1,2 @@
 export { IEconomicStrategy } from './IEconomicStrategy';
-export { shouldClaimTx } from './EconomicStrategyHelpers';
+export { shouldClaimTx, getExecutionGasPrice } from './EconomicStrategyHelpers';

--- a/src/EconomicStrategy/index.ts
+++ b/src/EconomicStrategy/index.ts
@@ -1,2 +1,2 @@
 export { IEconomicStrategy } from './IEconomicStrategy';
-export { shouldClaimTx, getExecutionGasPrice } from './EconomicStrategyHelpers';
+export { shouldClaimTx, shouldExecuteTx, getExecutionGasPrice } from './EconomicStrategyHelpers';

--- a/src/Router/Router.ts
+++ b/src/Router/Router.ts
@@ -1,7 +1,7 @@
 import Actions from '../Actions';
 import Config from '../Config';
 import { TxStatus, ClaimStatus, ExecuteStatus } from '../Enum';
-import { shouldClaimTx } from '../EconomicStrategy';
+import { shouldClaimTx, shouldExecuteTx } from '../EconomicStrategy';
 
 import W3Util from '../Util';
 import { ITxRequest } from '../Types';
@@ -110,21 +110,29 @@ export default class Router {
       return TxStatus.ExecutionWindow;
     }
 
-    try {
-      const executed: ExecuteStatus = await this.actions.execute(txRequest);
+    const shouldExecute = await shouldExecuteTx(txRequest, this.config);
 
-      if (executed === ExecuteStatus.SUCCESS) {
-        this.config.logger.info(`${txRequest.address} executed`);
+    if (shouldExecute) {
+      try {
+        const executionStatus: ExecuteStatus = await this.actions.execute(txRequest);
 
-        return TxStatus.Executed;
-      } else {
-        this.config.logger.debug(`${txRequest.address} error: ${executed}`);
+        if (executionStatus === ExecuteStatus.SUCCESS) {
+          this.config.logger.info(`${txRequest.address} executed`);
+
+          return TxStatus.Executed;
+        } else {
+          this.config.logger.debug(`${txRequest.address} error: ${executionStatus}`);
+        }
+      } catch (e) {
+        this.config.logger.error(`${txRequest.address} execution failed`);
+
+        //TODO handle gracefully?
+        throw new Error(e);
       }
-    } catch (e) {
-      this.config.logger.error(`${txRequest.address} execution failed`);
-
-      //TODO handle gracefully?
-      throw new Error(e);
+    } else {
+      this.config.logger.info(
+        `[${txRequest.address}] not profitable to execute. Gas price too high`
+      );
     }
 
     return TxStatus.ExecutionWindow;

--- a/src/Router/Router.ts
+++ b/src/Router/Router.ts
@@ -117,14 +117,14 @@ export default class Router {
         const executionStatus: ExecuteStatus = await this.actions.execute(txRequest);
 
         if (executionStatus === ExecuteStatus.SUCCESS) {
-          this.config.logger.info(`${txRequest.address} executed`);
+          this.config.logger.info(`[${txRequest.address}] executed`);
 
           return TxStatus.Executed;
         } else {
-          this.config.logger.debug(`${txRequest.address} error: ${executionStatus}`);
+          this.config.logger.debug(`[${txRequest.address}] error: ${executionStatus}`);
         }
       } catch (e) {
-        this.config.logger.error(`${txRequest.address} execution failed`);
+        this.config.logger.error(`[${txRequest.address}] execution failed`);
 
         //TODO handle gracefully?
         throw new Error(e);

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -1,10 +1,19 @@
 import { IBlock } from './Types';
+import BigNumber from 'bignumber.js';
 
 export default class W3Util {
   public web3: any;
 
   constructor(web3: any) {
     this.web3 = web3;
+  }
+
+  public calculateGasAmount(txRequest: any): BigNumber {
+    return txRequest.callGas
+      .add(180000)
+      .div(64)
+      .times(65)
+      .round();
   }
 
   public estimateGas(opts: any): Promise<any> {

--- a/test/e2e/TestScheduleTx.ts
+++ b/test/e2e/TestScheduleTx.ts
@@ -73,7 +73,7 @@ export const scheduleTestTx = async () => {
   const { callValue } = SCHEDULED_TX_PARAMS;
 
   const callGas = new BigNumber(1000000);
-  const gasPrice = new BigNumber(1);
+  const gasPrice = new BigNumber(web3.toWei(1, 'gwei'));
   const fee = new BigNumber(0);
   const bounty = new BigNumber(0);
 
@@ -98,7 +98,7 @@ export const scheduleTestTx = async () => {
     callValue,
     '255', // windowSize
     latestBlock + 270, // windowStart
-    1, // gasPrice
+    gasPrice, // gasPrice
     fee,
     bounty,
     '0', // requiredDeposit

--- a/test/e2e/TestScheduleTx.ts
+++ b/test/e2e/TestScheduleTx.ts
@@ -73,7 +73,7 @@ export const scheduleTestTx = async () => {
   const { callValue } = SCHEDULED_TX_PARAMS;
 
   const callGas = new BigNumber(1000000);
-  const gasPrice = new BigNumber(web3.toWei(1, 'gwei'));
+  const gasPrice = new BigNumber(web3.toWei(20, 'gwei'));
   const fee = new BigNumber(0);
   const bounty = new BigNumber(0);
 

--- a/test/helpers/mockConfig.ts
+++ b/test/helpers/mockConfig.ts
@@ -21,7 +21,8 @@ const mockConfig = (preConfig?: any) => {
     economicStrategy: {
       maxDeposit: new BigNumber(0),
       minBalance: new BigNumber(0),
-      minProfitability: new BigNumber(0)
+      minProfitability: new BigNumber(0),
+      maxGasSubsidy: 0
     },
     logger: new MockLogger(),
     ms: 4000,

--- a/test/helpers/mockConfig.ts
+++ b/test/helpers/mockConfig.ts
@@ -22,7 +22,7 @@ const mockConfig = (preConfig?: any) => {
       maxDeposit: new BigNumber(0),
       minBalance: new BigNumber(0),
       minProfitability: new BigNumber(0),
-      maxGasSubsidy: 0
+      maxGasSubsidy: 100
     },
     logger: new MockLogger(),
     ms: 4000,

--- a/test/unit/UnitTestEconomicStrategy.ts
+++ b/test/unit/UnitTestEconomicStrategy.ts
@@ -2,7 +2,7 @@ import BigNumber from 'bignumber.js';
 import { assert } from 'chai';
 import { Config } from '../../src/index';
 import { mockConfig, MockTxRequest } from '../helpers';
-import { shouldClaimTx } from '../../src/EconomicStrategy';
+import { shouldClaimTx, getExecutionGasPrice } from '../../src/EconomicStrategy';
 
 describe('Economic Strategy Tests', () => {
   let config: Config;
@@ -43,6 +43,47 @@ describe('Economic Strategy Tests', () => {
       config.economicStrategy.minProfitability = new BigNumber(config.web3.toWei(100, 'ether'));
       const shouldClaim = await shouldClaimTx(txTimestamp, config);
       assert.isFalse(shouldClaim);
+    });
+  });
+
+  describe('getExecutionGasPrice()', () => {
+    it('returns current network price if economic strategy not set', async () => {
+      config.economicStrategy = null;
+      const currentNetworkPrice = await config.util.networkGasPrice();
+      const gasPrice = await getExecutionGasPrice(txTimestamp, config);
+      assert.equal(gasPrice.toNumber(), currentNetworkPrice.toNumber());
+    });
+
+    it('returns current network price if maxGasSubsidy not set', async () => {
+      config.economicStrategy.maxGasSubsidy = null;
+      const currentNetworkPrice = await config.util.networkGasPrice();
+      const gasPrice = await getExecutionGasPrice(txTimestamp, config);
+      assert.equal(gasPrice.toNumber(), currentNetworkPrice.toNumber());
+    });
+
+    it('returns tx gas price if current network price lower than tx gas price', async () => {
+      const gasPrice = await getExecutionGasPrice(txTimestamp, config);
+      assert.equal(gasPrice.toNumber(), txTimestamp.gasPrice.toNumber());
+    });
+
+    it('returns current network price if (tx gas price + subsidy) higher than current network price', async () => {
+      txTimestamp.gasPrice = new BigNumber(config.web3.toWei(19, 'gwei'));
+      config.economicStrategy.maxGasSubsidy = 100;
+      const currentNetworkPrice = await config.util.networkGasPrice();
+      const gasPrice = await getExecutionGasPrice(txTimestamp, config);
+      assert.equal(gasPrice.toNumber(), currentNetworkPrice.toNumber());
+    });
+
+    it('returns (tx gas price + subsidy) if (tx gas price + subsidy) lower than current network price', async () => {
+      txTimestamp.gasPrice = new BigNumber(config.web3.toWei(19, 'gwei'));
+      config.economicStrategy.maxGasSubsidy = 1;
+
+      const expectedResult = txTimestamp.gasPrice.plus(
+        txTimestamp.gasPrice.times(config.economicStrategy.maxGasSubsidy / 100)
+      );
+
+      const gasPrice = await getExecutionGasPrice(txTimestamp, config);
+      assert.equal(gasPrice.toNumber(), expectedResult.toNumber());
     });
   });
 });


### PR DESCRIPTION
Adjusts `timenode-core` to the latest changes in the EAC protocol https://github.com/ethereum-alarm-clock/ethereum-alarm-clock/pull/149.

If the network conditions during execution require a gas price higher than set in the scheduled transaction, the **TimeNodes now use the gas price optimal for those network conditions.**

**Additional:**
- Adds an additional economic strategy parameter _maxGasSubsidy_ which defines TimeNode's willingness to subsidize the gas price in case of spikes.

**maxGasSubsidy** - number 0-100
- Percentage of the original transaction gas price which the TimeNode is willing to add to the gasPrice in case of network gas price spikes.

If no _maxGasSubsidy_ is set in the economic strategy, the TimeNode will use current best network gas price in case the current best network gas price is higher than the gas price set in the transaction.

_Note: TimeNode still guarantees that it will send at least the minimum amount of gas set in the transaction._


**UPDATE:**
This PR also adds a check which stops the TimeNodes from executing transactions which bring a negative profit should the gas cost go up significantly at the time of execution.