### PR TITLE
Remove backup scanner

### DIFF
--- a/src/Scanner/Scanner.ts
+++ b/src/Scanner/Scanner.ts
@@ -5,7 +5,6 @@ declare const clearInterval: any;
 declare const setInterval: any;
 
 import { IBlock, IntervalId, ITxRequest } from '../Types';
-
 import { Bucket, IBucketPair, IBuckets, BucketSize } from '../Buckets';
 import W3Util from '../Util';
 import { CacheStates } from '../Enum';
@@ -66,22 +65,11 @@ export default class {
     if (!this.config.clientSet()) {
       await this.config.awaitClientSet();
     }
-
-    if (await this.util.isWatchingEnabled()) {
-      // Watching is enabled! start watching the chain.
-      this.config.logger.info('Watching ENABLED');
-      this.chainScanner = await this.runAndSetInterval(() => this.watchBlockchain(), 5 * 60 * 1000);
-    } else {
-      // Watchin disabled. We use old-school methods.
-      this.config.logger.info('Watching DISABLED');
-      this.config.logger.info('-Initiating Backup Scanner-');
-      this.chainScanner = await this.runAndSetInterval(
-        () => this.backupScanBlockchain(),
-        this.config.ms
-      );
+    if (!(await this.util.isWatchingEnabled())) {
+      throw new Error('We are currently supporting nodes with filtering capabilities');
     }
 
-    // Create the interval for processing the transaction requests in cache.
+    this.chainScanner = await this.runAndSetInterval(() => this.watchBlockchain(), 5 * 60 * 1000);
     this.cacheScanner = await this.runAndSetInterval(() => this.scanCache(), this.config.ms);
 
     // Mark that we've started.
@@ -163,19 +151,6 @@ export default class {
 
       this.config.statsDb.incrementDiscovered(this.config.wallet.getAddresses()[0]);
     }
-  }
-
-  public async backupScanBlockchain(): Promise<void> {
-    // TODO only init reqFactory once, so check here with a function before calling again
-    const reqFactory = await this.requestFactory;
-    const { currentBuckets, nextBuckets } = await this.getBuckets();
-    const handleRequest = this.handleRequest.bind(this);
-
-    // TODO: extract this out
-    (await reqFactory.getRequestsByBucket(currentBuckets.blockBucket)).map(handleRequest);
-    (await reqFactory.getRequestsByBucket(currentBuckets.timestampBucket)).map(handleRequest);
-    (await reqFactory.getRequestsByBucket(nextBuckets.blockBucket)).map(handleRequest);
-    (await reqFactory.getRequestsByBucket(nextBuckets.timestampBucket)).map(handleRequest);
   }
 
   public async stopWatcher(bucket: Bucket) {

--- a/test/unit/UnitTestScanner.ts
+++ b/test/unit/UnitTestScanner.ts
@@ -42,13 +42,13 @@ describe('Scanner Unit Tests', () => {
   });
 
   describe('start()', async () => {
-    it('fails to start scanner with Null client', (done) => {
+    it('fails to start scanner with Null client', done => {
       config.client = undefined;
       scanner.start();
       setTimeout(() => {
         expect(scanner.scanning).to.be.false;
         done();
-      }, (5000));
+      }, 5000);
     }).timeout(6000);
 
     it('returns true for scanning and chainScanner/cacheScanner', async () => {
@@ -60,10 +60,7 @@ describe('Scanner Unit Tests', () => {
 
     it('returns true when watching disabled', async () => {
       scanner.util.isWatchingEnabled = () => Promise.resolve(false);
-      await scanner.start();
-      assert.isTrue(scanner.scanning);
-      expect(scanner.cacheScanner).to.exist;
-      expect(scanner.chainScanner).to.exist;
+      expect(scanner.start).to.throw;
     }).timeout(5000);
   });
 


### PR DESCRIPTION
Using the provider without watch functionality will end up with an Error throw by scanner. This has to be handlede by top layers (UI, CLI)