### PR TITLE
[FIX] 1.0.0-beta.4 deploy tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "babel-polyfill": "6.26.0",
     "bignumber.js": "5.0.0",
-    "eac.js-lib": "2.3.3",
+    "eac.js-lib": "https://github.com/ethereum-alarm-clock/eac.js-lib.git#fix/deploy",
     "ethereumjs-tx": "1.3.7",
     "ethereumjs-wallet": "0.6.2",
     "lokijs": "1.5.5",


### PR DESCRIPTION
Dependent on ethereum-alarm-clock/eac.js-lib#37
`eac.js-lib` version should be pointed to updated eac.js version