### PR TITLE
WIP: Account for gas price higher than minimum gas price

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9497,7 +9497,6 @@
       "integrity": "sha512-VU6/DSUX93d1fCzBz7WP/SGCQizO1rKZi4Px9j/3yRyfssHyFcZamMw2/sj4E8TlfMXONvZLoforR8B4bRoyTQ==",
       "dev": true,
       "requires": {
-        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
         "crypto-js": "^3.1.4",
         "utf8": "^2.1.1",
         "xhr2-cookies": "^1.1.0",
@@ -9506,8 +9505,7 @@
       "dependencies": {
         "bignumber.js": {
           "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
-          "dev": true
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
         },
         "crypto-js": {
           "version": "3.1.8",

--- a/src/Actions/Actions.ts
+++ b/src/Actions/Actions.ts
@@ -124,14 +124,7 @@ export default class Actions implements IActions {
             executionStatus = ExecuteStatus.FAILED;
           }
 
-          this.ledger.accountExecution(
-            txRequest,
-            receipt,
-            opts,
-            from,
-            success,
-            await txRequest.claimPaymentModifier()
-          );
+          this.ledger.accountExecution(txRequest, receipt, opts, from, success);
 
           return executionStatus;
         case TxSendErrors.WALLET_BUSY:

--- a/src/Actions/Actions.ts
+++ b/src/Actions/Actions.ts
@@ -124,7 +124,14 @@ export default class Actions implements IActions {
             executionStatus = ExecuteStatus.FAILED;
           }
 
-          this.ledger.accountExecution(txRequest, receipt, opts, from, success);
+          this.ledger.accountExecution(
+            txRequest,
+            receipt,
+            opts,
+            from,
+            success,
+            await txRequest.claimPaymentModifier()
+          );
 
           return executionStatus;
         case TxSendErrors.WALLET_BUSY:

--- a/src/Actions/Ledger.ts
+++ b/src/Actions/Ledger.ts
@@ -12,8 +12,7 @@ export interface ILedger {
     receipt: any,
     opts: ITransactionOptions,
     from: string,
-    success: boolean,
-    paymentModifier: BigNumber
+    success: boolean
   ): boolean;
 }
 
@@ -52,23 +51,17 @@ export class Ledger implements ILedger {
     receipt: any,
     opts: ITransactionOptions,
     from: string,
-    success: boolean,
-    paymentModifier: BigNumber
+    success: boolean
   ): boolean {
     let bounty = new BigNumber(0);
     let cost = new BigNumber(0);
 
     const gasUsed = new BigNumber(receipt.gasUsed);
-    const minimumGasPrice = (txRequest.gasPrice as any)() || new BigNumber(0); //TODO types seem messed up here
     const actualGasPrice = opts.gasPrice;
-
-    console.log(txRequest.gasPrice);
 
     if (success) {
       const data = receipt.logs[0].data;
-      bounty = new BigNumber(data.slice(0, 66)).sub(
-        gasUsed.mul(actualGasPrice.sub(minimumGasPrice))
-      );
+      bounty = new BigNumber(data.slice(0, 66)).sub(gasUsed.mul(actualGasPrice));
     } else {
       cost = gasUsed.mul(actualGasPrice);
     }

--- a/src/Actions/Ledger.ts
+++ b/src/Actions/Ledger.ts
@@ -68,7 +68,7 @@ export class Ledger implements ILedger {
       const actualGasPrice = new BigNumber(`0x${data.slice(66, 130)}`);
       const totalBounty = bounty.mul(paymentModifier);
       const totalMinimumCost = gasUsed.mul(minimumGasPrice);
-      const totalReimbursedCost = actualGasPrice.mul(gasUsed);
+      const totalReimbursedCost = gasUsed.mul(actualGasPrice);
 
       cost = totalBounty.add(totalMinimumCost).sub(totalReimbursedCost);
     } else {

--- a/src/Actions/Ledger.ts
+++ b/src/Actions/Ledger.ts
@@ -62,11 +62,13 @@ export class Ledger implements ILedger {
     const minimumGasPrice = (txRequest.gasPrice as any)() || new BigNumber(0); //TODO types seem messed up here
     const actualGasPrice = opts.gasPrice;
 
+    console.log(txRequest.gasPrice);
+
     if (success) {
       const data = receipt.logs[0].data;
-      bounty = new BigNumber(data.slice(0, 66))
-        .sub(gasUsed.mul(actualGasPrice.sub(minimumGasPrice)))
-        .mul(paymentModifier);
+      bounty = new BigNumber(data.slice(0, 66)).sub(
+        gasUsed.mul(actualGasPrice.sub(minimumGasPrice))
+      );
     } else {
       cost = gasUsed.mul(actualGasPrice);
     }

--- a/src/Actions/Ledger.ts
+++ b/src/Actions/Ledger.ts
@@ -56,7 +56,7 @@ export class Ledger implements ILedger {
     paymentModifier: BigNumber
   ): boolean {
     let bounty = new BigNumber(0);
-    let cost = new BigNumber(0);
+    let cost;
 
     const gasUsed = new BigNumber(receipt.gasUsed);
     const minimumGasPrice = new BigNumber(opts.gasPrice);

--- a/test/unit/UnitTestLedger.ts
+++ b/test/unit/UnitTestLedger.ts
@@ -95,7 +95,7 @@ describe('Ledger Unit Tests', async () => {
 
     const totalBounty = expectedReward.mul(paymentModifier);
     const totalMinimumCost = gasUsed.mul(minimumGasPrice);
-    const totalReimbursedCost = actualGasPrice.mul(gasUsed);
+    const totalReimbursedCost = gasUsed.mul(actualGasPrice);
 
     const expectedCost = totalBounty.add(totalMinimumCost).sub(totalReimbursedCost);
 


### PR DESCRIPTION
Fixes https://github.com/ethereum-alarm-clock/timenode-core/issues/194

I'd like some insight on how exactly to grab the actual gas price used, not sure exactly where to slice it out of the receipt.