### PR TITLE
Prioritize execution over other actions 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3182,8 +3182,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3201,13 +3200,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3220,18 +3217,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3334,8 +3328,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3345,7 +3338,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3358,20 +3350,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3388,7 +3377,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3461,8 +3449,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3472,7 +3459,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3548,8 +3534,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3579,7 +3564,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3597,7 +3581,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3636,13 +3619,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -6017,7 +5998,6 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -6339,8 +6319,7 @@
         "is-buffer": {
           "version": "1.1.6",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -6424,7 +6403,6 @@
           "version": "3.2.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -6471,8 +6449,7 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -6738,8 +6715,7 @@
         "repeat-string": {
           "version": "1.6.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "require-directory": {
           "version": "2.1.1",

--- a/src/Actions/Ledger.ts
+++ b/src/Actions/Ledger.ts
@@ -4,12 +4,18 @@ import { IStatsDB } from '../Stats/StatsDB';
 import { ITxRequest } from '../Types';
 import ITransactionOptions from '../Types/ITransactionOptions';
 import { isTransactionStatusSuccessful } from './Helpers';
+import { ITransactionReceipt } from '../Types/ITransactionReceipt';
 
 export interface ILedger {
-  accountClaiming(receipt: any, txRequest: ITxRequest, opts: any, from: string): boolean;
+  accountClaiming(
+    receipt: ITransactionReceipt,
+    txRequest: ITxRequest,
+    opts: any,
+    from: string
+  ): boolean;
   accountExecution(
     txRequest: ITxRequest,
-    receipt: any,
+    receipt: ITransactionReceipt,
     opts: ITransactionOptions,
     from: string,
     success: boolean
@@ -24,7 +30,7 @@ export class Ledger implements ILedger {
   }
 
   public accountClaiming(
-    receipt: any,
+    receipt: ITransactionReceipt,
     txRequest: ITxRequest,
     opts: ITransactionOptions,
     from: string
@@ -48,7 +54,7 @@ export class Ledger implements ILedger {
 
   public accountExecution(
     txRequest: ITxRequest,
-    receipt: any,
+    receipt: ITransactionReceipt,
     opts: ITransactionOptions,
     from: string,
     success: boolean

--- a/src/Cache/Cache.ts
+++ b/src/Cache/Cache.ts
@@ -50,25 +50,10 @@ export default class Cache<T> {
   }
 
   public stored() {
-    return Object.keys(this.cache);
+    return Object.keys(this.cache) || [];
   }
 
   public isEmpty() {
     return this.length() === 0;
-  }
-
-  public getTxRequestsClaimedBy(address: string): string[] {
-    const storedInCache = this.stored();
-    if (!storedInCache) {
-      return [''];
-    }
-
-    return storedInCache
-      .filter((txRequestAddress: string) => this.get(txRequestAddress))
-      .filter(async (txRequestAddress: string) => {
-        const txRequest = await this.eac.transactionRequest(txRequestAddress);
-        await txRequest.refreshData();
-        return txRequest.claimedBy === address;
-      });
   }
 }

--- a/src/Cache/Cache.ts
+++ b/src/Cache/Cache.ts
@@ -1,10 +1,12 @@
 import { ILogger, DefaultLogger } from '../Logger';
 import BigNumber from 'bignumber.js';
+import { TxStatus } from '../Enum';
 
 export interface ICachedTxDetails {
   claimedBy: string;
   wasCalled: boolean;
   windowStart: BigNumber;
+  status: TxStatus;
 }
 
 export default class Cache<T> {

--- a/src/Cache/Cache.ts
+++ b/src/Cache/Cache.ts
@@ -10,11 +10,9 @@ export interface ICachedTxDetails {
 export default class Cache<T> {
   public cache: {} = {};
   public logger: any;
-  private eac: any;
 
-  constructor(eac: any, logger: ILogger = new DefaultLogger()) {
+  constructor(logger: ILogger = new DefaultLogger()) {
     this.logger = logger;
-    this.eac = eac;
   }
 
   public set(key: string, value: T) {

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -76,7 +76,7 @@ export default class Config implements IConfigParams {
     this.logger = params.logger || new DefaultLogger();
     this.txPool = new TxPool(this);
     this.transactionReceiptAwaiter = new TransactionReceiptAwaiter(this.util);
-    this.cache = new Cache(this.eac, this.logger);
+    this.cache = new Cache(this.logger);
     this.economicStrategyManager = new EconomicStrategyManager(
       this.economicStrategy,
       this.util,

--- a/src/EconomicStrategy/EconomicStrategyManager.ts
+++ b/src/EconomicStrategy/EconomicStrategyManager.ts
@@ -151,6 +151,13 @@ export class EconomicStrategyManager {
     return false;
   }
 
+  private getTxRequestsClaimedBy(address: string): string[] {
+    return this.cache.stored().filter((txAddress: string) => {
+      const tx = this.cache.get(txAddress);
+      return tx.claimedBy === address && !tx.wasCalled;
+    });
+  }
+
   /**
    * Checks if the balance of the TimeNode is above a set limit.
    * @param {Config} config TimeNode configuration object.
@@ -164,7 +171,7 @@ export class EconomicStrategyManager {
     // Subtract the maximum gas costs of executing all currently claimed
     // transactions. This is to ensure that a TimeNode does not fail to execute
     // because it ran out of funds.
-    const txRequestsClaimed: string[] = this.cache.getTxRequestsClaimedBy(nextAccount);
+    const txRequestsClaimed: string[] = this.getTxRequestsClaimedBy(nextAccount);
 
     this.logger.debug(`txRequestClaimed=${txRequestsClaimed}`);
 

--- a/src/Router/Router.ts
+++ b/src/Router/Router.ts
@@ -68,6 +68,7 @@ export default class Router implements IRouter {
     }
 
     if (!(await txRequest.inClaimWindow()) || txRequest.isClaimed) {
+      this.cache.get(txRequest.address).claimedBy = txRequest.claimedBy;
       return TxStatus.FreezePeriod;
     }
 
@@ -156,13 +157,14 @@ export default class Router implements IRouter {
     return TxStatus.ExecutionWindow;
   }
 
-  public async executed(): Promise<TxStatus> {
+  public async executed(txRequest: ITxRequest): Promise<TxStatus> {
     /**
      * We don't cleanup because cleanup needs refactor according to latest logic in EAC
      * https://github.com/ethereum-alarm-clock/ethereum-alarm-clock/blob/master/contracts/Library/RequestLib.sol#L433
      *
      * await this.actions.cleanup(txRequest);
      */
+    this.cache.get(txRequest.address).wasCalled = true;
 
     return TxStatus.Done;
   }

--- a/src/Scanner/CacheScanner.ts
+++ b/src/Scanner/CacheScanner.ts
@@ -1,7 +1,8 @@
-import { IntervalId, Address, ITxRequest } from '../Types';
+import { IntervalId, ITxRequest } from '../Types';
 import BaseScanner from './BaseScanner';
 import IRouter from '../Router';
 import Config from '../Config';
+import { TxStatus } from '../Enum';
 
 export default class CacheScanner extends BaseScanner {
   public cacheInterval: IntervalId;
@@ -18,9 +19,20 @@ export default class CacheScanner extends BaseScanner {
 
     this.config.cache
       .stored()
-      .filter((address: Address) => this.config.cache.get(address))
-      .map((address: Address) => this.config.eac.transactionRequest(address))
-      .forEach((txRequest: ITxRequest) => this.route(txRequest));
+      .map(address => this.config.eac.transactionRequest(address))
+      .sort((a, b) => this.prioritize(a, b))
+      .forEach(txRequest => this.route(txRequest));
+  }
+
+  private prioritize(a: ITxRequest, b: ITxRequest): number {
+    const statusA = this.config.cache.get(a.address).status;
+    const statusB = this.config.cache.get(b.address).status;
+
+    if (statusA === statusB) {
+      return 0;
+    }
+
+    return statusA === TxStatus.FreezePeriod && statusB !== TxStatus.FreezePeriod ? 1 : -1;
   }
 
   private async route(txRequest: ITxRequest): Promise<void> {

--- a/src/Scanner/CacheScanner.ts
+++ b/src/Scanner/CacheScanner.ts
@@ -17,7 +17,7 @@ export default class CacheScanner extends BaseScanner {
       return;
     }
 
-    this.config.cache
+    return this.config.cache
       .stored()
       .map(address => this.config.eac.transactionRequest(address))
       .sort((a, b) => this.prioritize(a, b))
@@ -32,7 +32,7 @@ export default class CacheScanner extends BaseScanner {
       return 0;
     }
 
-    return statusA === TxStatus.FreezePeriod && statusB !== TxStatus.FreezePeriod ? 1 : -1;
+    return statusA === TxStatus.FreezePeriod && statusB !== TxStatus.FreezePeriod ? -1 : 1;
   }
 
   private async route(txRequest: ITxRequest): Promise<void> {

--- a/src/Scanner/ChainScanner.ts
+++ b/src/Scanner/ChainScanner.ts
@@ -4,6 +4,7 @@ import { IntervalId, Address } from '../Types';
 import CacheScanner from './CacheScanner';
 import { Bucket, IBuckets, BucketCalc, IBucketCalc } from '../Buckets';
 import { ITxRequestRaw } from '../Types/ITxRequest';
+import { TxStatus } from '../Enum';
 
 export default class ChainScanner extends CacheScanner {
   public bucketCalc: IBucketCalc;
@@ -143,7 +144,8 @@ export default class ChainScanner extends CacheScanner {
     this.config.cache.set(txRequest.address, {
       claimedBy: null,
       wasCalled: false,
-      windowStart: txRequest.params[7]
+      windowStart: txRequest.params[7],
+      status: TxStatus.BeforeClaimWindow
     });
   }
 }

--- a/test/helpers/MockTxRequest.ts
+++ b/test/helpers/MockTxRequest.ts
@@ -17,13 +17,11 @@ const mockTxRequest = async (web3: any, isBlock?: boolean): Promise<ITxRequest> 
       .add(num, 'day')
       .unix();
 
-  const blocksLater = (num: number) => currentBlockNumber + num;
-
-  const oneHourWindowSize = new BigNumber(isBlock ? 255 : 3600);
-
   const currentBlockNumber = (await Bb.fromCallback((callback: any) =>
     web3.eth.getBlockNumber(callback)
   )) as number;
+  const blocksLater = (num: number) => currentBlockNumber + num;
+  const oneHourWindowSize = new BigNumber(isBlock ? 255 : 3600);
 
   return {
     address: '0x24f8e3501b00bd219e864650f5625cd4f9272a25',

--- a/test/unit/UnitTestEconomicStrategy.ts
+++ b/test/unit/UnitTestEconomicStrategy.ts
@@ -52,7 +52,7 @@ describe('Economic Strategy Tests', () => {
   const defaultUtil = createUtil();
 
   const cache = TypeMoq.Mock.ofType<Cache<ICachedTxDetails>>();
-  cache.setup(c => c.getTxRequestsClaimedBy(TypeMoq.It.isAnyString())).returns(() => []);
+  cache.setup(c => c.stored()).returns(() => []);
 
   describe('shouldClaimTx()', () => {
     it('returns CLAIM if economic strategy not set or default', async () => {

--- a/test/unit/UnitTestRouter.ts
+++ b/test/unit/UnitTestRouter.ts
@@ -2,13 +2,16 @@
 import { expect, assert } from 'chai';
 import * as TypeMoq from 'typemoq';
 
-import { Config, Wallet } from '../../src/index';
+import { Config, Wallet, W3Util } from '../../src/index';
 import { mockConfig, mockTxRequest, mockTxStatus } from '../helpers';
 import Actions from '../../src/Actions';
 import Router from '../../src/Router';
-import { TxStatus } from '../../src/Enum';
+import { TxStatus, EconomicStrategyStatus } from '../../src/Enum';
 import { ITxRequest } from '../../src/Types';
 import { V3Wallet } from '../../src/Wallet/Wallet';
+import { BigNumber } from 'bignumber.js';
+import { IEconomicStrategyManager } from '../../src/EconomicStrategy/EconomicStrategyManager';
+import { ICachedTxDetails } from '../../src/Cache';
 
 const TIMESTAMP_TX = 'timestamp Tx';
 const BLOCK_TX = 'block Tx';
@@ -22,7 +25,14 @@ describe('Router Unit Tests', () => {
   let router: Router;
   let myAccount: string;
 
-  const createRouter = (claimingEnabled = true) => {
+  const createRouter = async (claimingEnabled = true) => {
+    const web3 = {
+      eth: {
+        getBlockNumber: (callback: any) => callback(null, 1000)
+      },
+      toWei: config.web3.toWei
+    };
+
     const v3wallet = TypeMoq.Mock.ofType<V3Wallet>();
     v3wallet.setup(w => w.getAddressString()).returns(() => myAccount);
 
@@ -34,32 +44,43 @@ describe('Router Unit Tests', () => {
     wallet.setup(w => w.isKnownAddress(myAccount)).returns(() => true);
     wallet.setup(w => w.isKnownAddress(TypeMoq.It.isAnyString())).returns(() => false);
 
+    const util = TypeMoq.Mock.ofType<W3Util>();
+    util.setup(u => u.networkGasPrice()).returns(async () => new BigNumber(20000));
+
+    const economicStrategyManager = TypeMoq.Mock.ofType<IEconomicStrategyManager>();
+    economicStrategyManager
+      .setup(e => e.shouldClaimTx(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+      .returns(async () => EconomicStrategyStatus.CLAIM);
+
+    txTimestamp = await mockTxRequest(web3);
+    txBlock = await mockTxRequest(web3, true);
+
+    config.cache.set(txTimestamp.address, {} as ICachedTxDetails);
+    config.cache.set(txBlock.address, {} as ICachedTxDetails);
+
     const actions = new Actions(
       config.wallet,
       config.ledger,
       config.logger,
       config.cache,
-      config.util,
+      util.object,
       config.pending,
-      config.economicStrategyManager
+      economicStrategyManager.object
     );
+
     return new Router(
       claimingEnabled,
       config.cache,
       config.logger,
       actions,
-      config.economicStrategyManager,
+      economicStrategyManager.object,
       wallet.object
     );
   };
 
   const reset = async () => {
     config = await mockConfig();
-
-    txTimestamp = await mockTxRequest(config.web3);
-    txBlock = await mockTxRequest(config.web3, true);
-
-    router = createRouter();
+    router = await createRouter();
     myAccount = config.wallet.getAddresses()[0];
   };
 
@@ -176,7 +197,7 @@ describe('Router Unit Tests', () => {
 
       it('returns ClaimWindow when claim window started and claiming disabled', async () => {
         const tx = await mockTxStatus(txTimestamp, TxStatus.ClaimWindow);
-        const routerLocal = createRouter(false);
+        const routerLocal = await createRouter(false);
         assert.equal(await routerLocal.claimWindow(tx), TxStatus.ClaimWindow);
       });
 
@@ -201,7 +222,7 @@ describe('Router Unit Tests', () => {
 
       it('returns ClaimWindow when claim window started and claiming disabled', async () => {
         const tx = await mockTxStatus(txBlock, TxStatus.ClaimWindow);
-        const routerLocal = createRouter(false);
+        const routerLocal = await createRouter(false);
         const status = await routerLocal.claimWindow(tx);
 
         assert.equal(status, TxStatus.ClaimWindow);
@@ -372,7 +393,7 @@ describe('Router Unit Tests', () => {
 
       it('returns ClaimWindow status when claiming disabled', async () => {
         const tx = await mockTxStatus(txTimestamp, TxStatus.ClaimWindow);
-        const routerLocal = createRouter(false);
+        const routerLocal = await createRouter(false);
         assert.equal(await routerLocal.route(tx), TxStatus.ClaimWindow);
       });
 
@@ -406,7 +427,7 @@ describe('Router Unit Tests', () => {
 
       it('returns ClaimWindow status when claiming disabled', async () => {
         const tx = await mockTxStatus(txBlock, TxStatus.ClaimWindow);
-        const routerLocal = createRouter(false);
+        const routerLocal = await createRouter(false);
         assert.equal(await routerLocal.route(tx), TxStatus.ClaimWindow);
       });
 

--- a/test/unit/UnitTestScanner.ts
+++ b/test/unit/UnitTestScanner.ts
@@ -73,15 +73,4 @@ describe('Scanner Unit Tests', () => {
       expect(scanner.buckets).to.haveOwnProperty('nextBuckets');
     });
   });
-
-  describe('scanCache()', () => {
-    it('does not route when cache empty', async () => {
-      const router = TypeMoq.Mock.ofType<IRouter>();
-      const localScanner = new Scanner(config, router.object);
-
-      await localScanner.scanCache();
-
-      router.verify(r => r.route(TypeMoq.It.isAny()), TypeMoq.Times.never());
-    });
-  });
 });

--- a/test/unit/UnitTestTimeNode.ts
+++ b/test/unit/UnitTestTimeNode.ts
@@ -2,6 +2,7 @@ import { expect, assert } from 'chai';
 import { TimeNode, Config } from '../../src/index';
 import { mockConfig } from '../helpers';
 import { BigNumber } from 'bignumber.js';
+import { TxStatus } from '../../src/Enum';
 
 describe('TimeNode Unit Tests', () => {
   let config: Config;
@@ -77,9 +78,9 @@ describe('TimeNode Unit Tests', () => {
     it('returns a transaction', () => {
       const tx = {
         claimedBy: config.wallet.getAddresses()[0],
-        claimingFailed: false,
         wasCalled: false,
-        windowStart: new BigNumber(10000)
+        windowStart: new BigNumber(10000),
+        status: TxStatus.FreezePeriod
       };
       config.cache.set('tx', tx);
 


### PR DESCRIPTION
Currently the fastest TX is being processed, others waits for another chance, there is no ordering mechanism. Now having many new transactions and 1 account, we might end up claiming transactions and because of that we may miss the execution.

The idea is to sort pending list by action, so executions first, rest further. 