### PR TITLE
[HOTFIX] Revert to legacy gas estimation for claiming (for now)

### DIFF
--- a/src/Actions/Actions.ts
+++ b/src/Actions/Actions.ts
@@ -158,7 +158,9 @@ export default class Actions implements IActions {
       to: txRequest.address,
       value: txRequest.requiredDeposit,
       gas: 120000,
-      gasPrice: await this.utils.networkGasPrice(),
+      // NOTE - as for why we use `getGasPrice` instead of `networkGasPrice` see
+      // note at `src/EconomicStrategy/EconomicStrategyManager.ts` line 221.
+      gasPrice: await this.utils.getGasPrice(),
       data: txRequest.claimData,
       operation: Operation.CLAIM
     };

--- a/src/EconomicStrategy/EconomicStrategyManager.ts
+++ b/src/EconomicStrategy/EconomicStrategyManager.ts
@@ -218,7 +218,13 @@ export class EconomicStrategyManager {
   private async isProfitable(txRequest: ITxRequest): Promise<boolean> {
     const paymentModifier = await txRequest.claimPaymentModifier();
     const claimingGas = new BigNumber(CLAIMING_GAS_ESTIMATE);
-    const claimingGasPrice = await this.util.networkGasPrice();
+    // NOTE - Here we use the legacy (web3 version) of getGasPrice instead of the
+    // networkGasPrice() call. This is to ensure backwards compatibility with older
+    // versions of the TimeNode. If TimeNodes disagree about the current gasPrice,
+    // we notice disambiguous behavior between client versions which make both versions suck more.
+    // Instead we opt for maintaining the sucky version for now, to keep the levels of
+    // suck constant instead of increasing them.
+    const claimingGasPrice = await this.util.getGasPrice();
     const claimingGasCost = claimingGasPrice.times(claimingGas);
 
     const reward = txRequest.bounty.times(paymentModifier).minus(claimingGasCost);

--- a/test/unit/UnitTestEconomicStrategy.ts
+++ b/test/unit/UnitTestEconomicStrategy.ts
@@ -43,6 +43,7 @@ describe('Economic Strategy Tests', () => {
   const createUtil = (gasPrice = defaultGasPrice) => {
     const util = TypeMoq.Mock.ofType<W3Util>();
     util.setup(u => u.networkGasPrice()).returns(() => Promise.resolve(gasPrice));
+    util.setup(u => u.getGasPrice()).returns(() => Promise.resolve(gasPrice));
     util.setup(u => u.balanceOf(TypeMoq.It.isAny())).returns(() => Promise.resolve(defaultBalance));
     util.setup(u => u.calculateGasAmount(TypeMoq.It.isAny())).returns(() => MWei);
 


### PR DESCRIPTION
As per discussion on ChronoLogic standup 5 October 2018. Added verbose note so we remember why we did this change when we decide it's time to come back and work on it.