### PR TITLE
Fixes timeleft estimate which was returning negative estimates

### DIFF
--- a/src/EconomicStrategy/EconomicStrategyManager.ts
+++ b/src/EconomicStrategy/EconomicStrategyManager.ts
@@ -221,8 +221,8 @@ export class EconomicStrategyManager {
     const inReservedWindow = await txRequest.inReservedWindow();
 
     const timeLeft = inReservedWindow
-      ? now.sub(txRequest.reservedWindowEnd)
-      : now.sub(txRequest.executionWindowEnd);
+      ? txRequest.reservedWindowEnd.sub(now)
+      : txRequest.executionWindowEnd.sub(now);
     const normalizedTimeLeft = temporalUnit === 1 ? timeLeft.mul(gasStats.blockTime) : timeLeft;
 
     const gasEstimation = new NormalizedTimes(gasStats, temporalUnit).pickGasPrice(


### PR DESCRIPTION
Problem: The `now` was assumed to be higher than the `executionWindowEnd` or `reservedWindowEnd` when in reality it is lower.

Fix: Switch around calculations.