### PR TITLE
Fixes expected reward calculation

### DIFF
--- a/src/EconomicStrategy/EconomicStrategyManager.ts
+++ b/src/EconomicStrategy/EconomicStrategyManager.ts
@@ -111,7 +111,9 @@ export class EconomicStrategyManager {
     const reward = bounty.times(paymentModifier);
 
     const gasCost = targetGasPrice.times(gasAmount);
-    const expectedReward = requiredDeposit.plus(reward).plus(reimbursement);
+    const expectedReward = reward
+      .plus(reimbursement)
+      .plus(txRequest.isClaimed ? requiredDeposit : 0);
     const shouldExecute = gasCost.lessThanOrEqualTo(expectedReward);
 
     this.logger.debug(


### PR DESCRIPTION
Problem: `requiredDeposit` was always adding into the expected reward calculation.

Fix: Check if the txRequest was claimed before adding the deposit as an expected reward.