### PR TITLE
Devp2p pool watcher

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1772,6 +1772,11 @@
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
+    "buffer-equals": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/buffer-equals/-/buffer-equals-1.0.4.tgz",
+      "integrity": "sha1-A1O1T9B/2VZBcGca5vZrnPENJ/U="
+    },
     "buffer-fill": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
@@ -2754,6 +2759,23 @@
             "lodash": "^4.17.10"
           }
         },
+        "ethereum-common": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
+          "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
+        },
+        "ethereumjs-block": {
+          "version": "1.7.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
+          "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
+          "requires": {
+            "async": "^2.0.1",
+            "ethereum-common": "0.2.0",
+            "ethereumjs-tx": "^1.2.2",
+            "ethereumjs-util": "^5.0.0",
+            "merkle-patricia-tree": "^2.1.2"
+          }
+        },
         "ethereumjs-util": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
@@ -2810,10 +2832,17 @@
       "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
       "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
       "requires": {
-        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
         "ethereumjs-util": "^5.1.1"
       },
       "dependencies": {
+        "ethereumjs-abi": {
+          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+          "requires": {
+            "bn.js": "^4.10.0",
+            "ethereumjs-util": "^5.0.0"
+          }
+        },
         "ethereumjs-util": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
@@ -2887,6 +2916,18 @@
           "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
           "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
         },
+        "ethereumjs-block": {
+          "version": "1.7.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
+          "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
+          "requires": {
+            "async": "^2.0.1",
+            "ethereum-common": "0.2.0",
+            "ethereumjs-tx": "^1.2.2",
+            "ethereumjs-util": "^5.0.0",
+            "merkle-patricia-tree": "^2.1.2"
+          }
+        },
         "ethereumjs-util": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
@@ -2948,33 +2989,9 @@
       }
     },
     "ethereum-common": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
-      "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
-    },
-    "ethereumjs-abi": {
-      "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
-      "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
-      "requires": {
-        "bn.js": "^4.10.0",
-        "ethereumjs-util": "^5.0.0"
-      },
-      "dependencies": {
-        "ethereumjs-util": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
-          "requires": {
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "ethjs-util": "^0.1.3",
-            "keccak": "^1.0.2",
-            "rlp": "^2.0.0",
-            "safe-buffer": "^5.1.1",
-            "secp256k1": "^3.0.1"
-          }
-        }
-      }
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.1.tgz",
+      "integrity": "sha512-SDMRn/+NQLXPomFvlYO+3KvW7dAwrwwZ81pM4llYJ1fHHwTV0RudmR4KK7QFOIH6WiuSydKsXyugxM2EtNxNOw=="
     },
     "ethereumjs-account": {
       "version": "2.0.5",
@@ -3003,12 +3020,12 @@
       }
     },
     "ethereumjs-block": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
-      "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.1.0.tgz",
+      "integrity": "sha512-ip+x4/7hUInX+TQfhEKsQh9MJK1Dbjp4AuPjf1UdX3udAV4beYD4EMCNIPzBLCsGS8WQZYXLpo83tVTISYNpow==",
       "requires": {
         "async": "^2.0.1",
-        "ethereum-common": "0.2.0",
+        "ethereumjs-common": "^0.6.0",
         "ethereumjs-tx": "^1.2.2",
         "ethereumjs-util": "^5.0.0",
         "merkle-patricia-tree": "^2.1.2"
@@ -3021,11 +3038,6 @@
           "requires": {
             "lodash": "^4.17.10"
           }
-        },
-        "ethereum-common": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
-          "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
         },
         "ethereumjs-util": {
           "version": "5.2.0",
@@ -3048,6 +3060,32 @@
       "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-0.6.1.tgz",
       "integrity": "sha512-4jOrfDu9qOBTTGGb3zrfT1tE1Hyc6a8LJpEk0Vk9AYlLkBY7crjVICyJpRvjNI+KLDMpMITMw3eWVZOLMtZdhw=="
     },
+    "ethereumjs-devp2p": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-devp2p/-/ethereumjs-devp2p-2.5.1.tgz",
+      "integrity": "sha512-xVizqoB44UqEaw/yc6PgmlDG4+wV4EnZ9b5S78kOUKOWQfrk91tmqO3WnxwHwFRLBsvzYB2P95YSc1ZDmMPvDA==",
+      "requires": {
+        "babel-runtime": "^6.11.6",
+        "bl": "^1.1.2",
+        "debug": "^2.2.0",
+        "inherits": "^2.0.1",
+        "ip": "^1.1.3",
+        "k-bucket": "^3.2.1",
+        "keccak": "^1.0.0",
+        "lru-cache": "^4.0.1",
+        "ms": "^0.7.1",
+        "rlp-encoding": "^3.0.0",
+        "safe-buffer": "^5.1.1",
+        "secp256k1": "^3.1.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+          "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8="
+        }
+      }
+    },
     "ethereumjs-tx": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
@@ -3057,6 +3095,11 @@
         "ethereumjs-util": "^5.0.0"
       },
       "dependencies": {
+        "ethereum-common": {
+          "version": "0.0.18",
+          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
+          "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
+        },
         "ethereumjs-util": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
@@ -4589,6 +4632,11 @@
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+    },
     "ipaddr.js": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
@@ -5109,6 +5157,16 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      }
+    },
+    "k-bucket": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-3.3.1.tgz",
+      "integrity": "sha512-kgwWqYT79rAahn4maIVTP8dIe+m1KulufWW+f1bB9DlZrRFiGpZ4iJOg2HUp4xJYBWONP3+rOPIWF/RXABU6mw==",
+      "requires": {
+        "buffer-equals": "^1.0.3",
+        "inherits": "^2.0.1",
+        "randombytes": "^2.0.3"
       }
     },
     "keccak": {
@@ -5662,7 +5720,6 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
       "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "dev": true,
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
@@ -6404,6 +6461,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -6728,7 +6786,8 @@
         "is-buffer": {
           "version": "1.1.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -6812,6 +6871,7 @@
           "version": "3.2.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -6858,7 +6918,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -7124,7 +7185,8 @@
         "repeat-string": {
           "version": "1.6.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "require-directory": {
           "version": "2.1.1",
@@ -7935,8 +7997,7 @@
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
       "version": "1.1.31",
@@ -8257,6 +8318,11 @@
       "requires": {
         "safe-buffer": "^5.1.1"
       }
+    },
+    "rlp-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rlp-encoding/-/rlp-encoding-3.0.0.tgz",
+      "integrity": "sha1-mZ24bdBObuj6lNQb4eiprjSJj9M="
     },
     "run-node": {
       "version": "1.0.0",
@@ -9888,8 +9954,19 @@
           "dev": true,
           "requires": {
             "underscore": "1.8.3",
-            "web3-core-helpers": "1.0.0-beta.36",
-            "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+            "web3-core-helpers": "1.0.0-beta.36"
+          },
+          "dependencies": {
+            "websocket": {
+              "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+              "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+              "requires": {
+                "debug": "^2.2.0",
+                "nan": "^2.3.3",
+                "typedarray-to-buffer": "^3.1.2",
+                "yaeti": "^0.0.6"
+              }
+            }
           }
         },
         "web3-shh": {
@@ -9922,7 +9999,6 @@
         "websocket": {
           "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
           "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
-          "dev": true,
           "requires": {
             "debug": "^2.2.0",
             "nan": "^2.3.3",
@@ -10249,8 +10325,19 @@
           "integrity": "sha512-8p6ZLv+1JYa5Vs8oBn33Nn3VGFBbF+wVfO+b78RJS1Qf1uIOzjFVDk3XwYDD7rlz9G5BKpxhaQw+6EGQ7L02aw==",
           "requires": {
             "underscore": "1.8.3",
-            "web3-core-helpers": "1.0.0-beta.37",
-            "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+            "web3-core-helpers": "1.0.0-beta.37"
+          },
+          "dependencies": {
+            "websocket": {
+              "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+              "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+              "requires": {
+                "debug": "^2.2.0",
+                "nan": "^2.3.3",
+                "typedarray-to-buffer": "^3.1.2",
+                "yaeti": "^0.0.6"
+              }
+            }
           }
         },
         "web3-utils": {
@@ -10352,6 +10439,23 @@
             "lodash": "^4.17.10"
           }
         },
+        "ethereum-common": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
+          "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
+        },
+        "ethereumjs-block": {
+          "version": "1.7.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
+          "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
+          "requires": {
+            "async": "^2.0.1",
+            "ethereum-common": "0.2.0",
+            "ethereumjs-tx": "^1.2.2",
+            "ethereumjs-util": "^5.0.0",
+            "merkle-patricia-tree": "^2.1.2"
+          }
+        },
         "ethereumjs-util": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
@@ -10393,13 +10497,12 @@
       "integrity": "sha512-Cx64NgDStynKaUGDIIOfaCd0fZusL8h5avKTkdTjUu2aHhFJhZoVBGVLhoDtUaqZGWIZGcBJOoVf2JkGUOjDRQ==",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.35",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+        "web3-core-helpers": "1.0.0-beta.35"
       },
       "dependencies": {
         "websocket": {
           "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-          "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+          "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
           "requires": {
             "debug": "^2.2.0",
             "nan": "^2.3.3",
@@ -10581,8 +10684,7 @@
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-      "dev": true
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
       "version": "3.32.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,10 @@
   "dependencies": {
     "@ethereum-alarm-clock/lib": "0.1.0",
     "bignumber.js": "5.0.0",
-    "ethereumjs-tx": "1.3.7",
+    "ethereum-common": "^0.2.1",
+    "ethereumjs-block": "^2.1.0",
+    "ethereumjs-devp2p": "^2.5.1",
+    "ethereumjs-tx": "^1.3.7",
     "ethereumjs-wallet": "0.6.3",
     "lokijs": "1.5.6",
     "node-fetch": "2.3.0"

--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
   "dependencies": {
     "@ethereum-alarm-clock/lib": "0.1.0",
     "bignumber.js": "5.0.0",
-    "ethereum-common": "^0.2.1",
-    "ethereumjs-block": "^2.1.0",
-    "ethereumjs-devp2p": "^2.5.1",
-    "ethereumjs-tx": "^1.3.7",
+    "ethereum-common": "0.2.1",
+    "ethereumjs-block": "2.1.0",
+    "ethereumjs-devp2p": "2.5.1",
+    "ethereumjs-tx": "1.3.7",
     "ethereumjs-wallet": "0.6.3",
     "lokijs": "1.5.6",
     "node-fetch": "2.3.0"

--- a/src/Actions/Pending.ts
+++ b/src/Actions/Pending.ts
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js';
 import { Operation } from '../Types/Operation';
-import { ITxPool, ITxPoolTxDetails } from '../TxPool';
 import { ITransactionRequestPending, GasPriceUtil } from '@ethereum-alarm-clock/lib';
+import { ITxPool, ITxPoolTxDetails } from '../TxPool/ITxPool';
 
 interface PendingOpts {
   type: Operation;

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -14,7 +14,7 @@ import { IEconomicStrategyManager } from '../EconomicStrategy/EconomicStrategyMa
 import { Ledger } from '../Actions/Ledger';
 import { Pending } from '../Actions/Pending';
 import { AccountState } from '../Wallet/AccountState';
-import { TxPool } from '../TxPool';
+import { TxPool, DirectTxPool, ITxPool } from '../TxPool';
 import Web3 = require('web3');
 
 export default class Config implements IConfigParams {
@@ -47,11 +47,12 @@ export default class Config implements IConfigParams {
   public scanSpread: any;
   public statsDb: StatsDB;
   public statsDbLoaded: Promise<boolean>;
-  public txPool: TxPool;
+  public txPool: ITxPool;
   public util: Util;
   public wallet: Wallet;
   public web3: Web3;
   public walletStoresAsPrivateKeys: boolean;
+  public directTxPool: boolean;
 
   // tslint:disable-next-line:cognitive-complexity
   constructor(params: IConfigParams) {
@@ -69,13 +70,16 @@ export default class Config implements IConfigParams {
     this.economicStrategy = params.economicStrategy || Config.DEFAULT_ECONOMIC_STRATEGY;
 
     this.autostart = params.autostart !== undefined ? params.autostart : true;
+    this.directTxPool = params.directTxPool || false;
     this.claiming = params.claiming || false;
     this.maxRetries = params.maxRetries || 30;
     this.ms = params.ms || 4000;
     this.scanSpread = params.scanSpread || 50;
     this.walletStoresAsPrivateKeys = params.walletStoresAsPrivateKeys || false;
     this.logger = params.logger || new DefaultLogger();
-    this.txPool = new TxPool(this.web3, this.util, this.logger);
+    this.txPool = this.directTxPool
+      ? new DirectTxPool(this.web3, this.logger)
+      : new TxPool(this.web3, this.util, this.logger);
     this.cache = new Cache(this.logger);
     this.economicStrategyManager = new EconomicStrategyManager(
       this.economicStrategy,

--- a/src/Config/IConfigParams.ts
+++ b/src/Config/IConfigParams.ts
@@ -14,4 +14,5 @@ export interface IConfigParams {
   statsDb?: any;
   walletStores?: any;
   walletStoresAsPrivateKeys?: boolean;
+  directTxPool?: boolean;
 }

--- a/src/Scanner/TimeNodeScanner.ts
+++ b/src/Scanner/TimeNodeScanner.ts
@@ -1,17 +1,18 @@
 /* eslint no-await-in-loop: 'off' */
-import ChainScanner from './ChainScanner';
+import { Util } from '@ethereum-alarm-clock/lib';
+
 import Config from '../Config';
 import IRouter from '../Router';
+import { ITxPool } from '../TxPool';
 import { IntervalId } from '../Types';
-import { TxPool } from '../TxPool';
-import { Util } from '@ethereum-alarm-clock/lib';
+import ChainScanner from './ChainScanner';
 
 declare const clearInterval: any;
 declare const setInterval: any;
 
 export interface ITimeNodeScanner {
   scanning: boolean;
-  txPool: TxPool;
+  txPool: ITxPool;
 
   start(): Promise<boolean>;
   stop(): Promise<boolean>;
@@ -19,7 +20,7 @@ export interface ITimeNodeScanner {
 
 export default class TimeNodeScanner extends ChainScanner implements ITimeNodeScanner {
   public scanning: boolean = false;
-  public txPool: TxPool;
+  public txPool: ITxPool;
 
   constructor(config: Config, router: IRouter) {
     super(config, router);

--- a/src/TxPool/DirectTxPool.ts
+++ b/src/TxPool/DirectTxPool.ts
@@ -131,7 +131,7 @@ export default class DirectTxPool implements ITxPool {
     const data = tx.data.toString('hex');
     let result = Operation.OTHER;
 
-    if (data.startsWith(DirectTxPool.ClaimData) || data.startsWith('a9059cbb')) {
+    if (data.startsWith(DirectTxPool.ClaimData)) {
       result = Operation.CLAIM;
     } else if (data.startsWith(DirectTxPool.ExecuteData)) {
       result = Operation.EXECUTE;

--- a/src/TxPool/DirectTxPool.ts
+++ b/src/TxPool/DirectTxPool.ts
@@ -1,0 +1,152 @@
+import BigNumber from 'bignumber.js';
+import { randomBytes } from 'crypto';
+import { bootstrapNodes } from 'ethereum-common';
+import { devp2p } from 'ethereumjs-devp2p';
+import EthereumTx = require('ethereumjs-tx');
+
+import { ITxPool, ITxPoolTxDetails } from '.';
+import { Operation } from '../Types/Operation';
+
+export default class DirectTxPool implements ITxPool {
+  private static ClientIdFilter = [
+    'go1.5',
+    'go1.6',
+    'go1.7',
+    'quorum',
+    'pirl',
+    'ubiq',
+    'gmc',
+    'gwhale',
+    'prichain'
+  ];
+  private static ExecuteData = '0x61461954';
+  private static ClaimData = '0x4e71d92d';
+
+  public pool: Map<string, ITxPoolTxDetails>;
+  private isRunning: boolean = false;
+  private chainId: number;
+  private privateKey: Buffer;
+
+  constructor(chainId: number) {
+    this.chainId = chainId;
+    this.privateKey = randomBytes(32);
+  }
+
+  public running(): boolean {
+    return this.isRunning;
+  }
+
+  public async start() {
+    if (!this.isRunning) {
+      this.startListening();
+    }
+  }
+  public async stop() {
+    throw new Error('Method not implemented.');
+  }
+
+  private get bootNodes() {
+    return bootstrapNodes
+      .filter((node: any) => {
+        return node.chainId === this.chainId;
+      })
+      .map((node: any) => {
+        return {
+          address: node.ip,
+          udpPort: node.port,
+          tcpPort: node.port
+        };
+      });
+  }
+
+  private bootstrap(bootNodes: any[]) {
+    const dpt = new devp2p.DPT(this.privateKey, {
+      refreshInterval: 30000,
+      endpoint: {
+        address: '0.0.0.0',
+        udpPort: null,
+        tcpPort: null
+      }
+    });
+
+    bootNodes.forEach((bootNode: any) => {
+      dpt.bootstrap(bootNode);
+    });
+
+    return dpt;
+  }
+
+  private register(dpt: any) {
+    return new devp2p.RLPx(this.privateKey, {
+      dpt,
+      maxPeers: 25,
+      capabilities: [devp2p.ETH.eth63, devp2p.ETH.eth62],
+      remoteClientIdFilter: DirectTxPool.ClientIdFilter,
+      listenPort: null
+    });
+  }
+
+  private sendStatus(eth: any) {
+    eth.sendStatus({
+      networkId: this.chainId,
+      td: devp2p._util.int2buffer(17179869184), // total difficulty in genesis block
+      bestHash: Buffer.from(
+        'd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3',
+        'hex'
+      ),
+      genesisHash: Buffer.from(
+        'd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3',
+        'hex'
+      )
+    });
+  }
+
+  private peerAdded(peer: any) {
+    const eth = peer.getProtocols()[0];
+
+    this.sendStatus(eth);
+    eth.on('message', async (code: any, payload: any[]) => {
+      if (code === devp2p.ETH.MESSAGE_CODES.TX) {
+        this.onTransaction(payload);
+      }
+    });
+  }
+
+  private decodeOperation(tx: EthereumTx): Operation {
+    const data = tx.data.toString('hex');
+    let result = null;
+
+    if (data.startsWith(DirectTxPool.ClaimData)) {
+      result = Operation.CLAIM;
+    } else if (data.startsWith(DirectTxPool.ExecuteData)) {
+      result = Operation.EXECUTE;
+    }
+
+    return result;
+  }
+
+  private onTransaction(payload: any[]) {
+    for (const rawTx of payload) {
+      const tx = new EthereumTx(rawTx);
+      const hash = tx.hash().toString('hex');
+      const operation = this.decodeOperation(tx);
+      if (!this.pool.has(hash) && tx.validate(false) && operation) {
+        this.pool.set(hash, {
+          to: tx.to.toString('hex'),
+          gasPrice: new BigNumber(tx.gasPrice.toString('hex')),
+          operation,
+          timestamp: new Date().getTime()
+        });
+      }
+    }
+  }
+
+  private startListening() {
+    const dpt = this.bootstrap(this.bootNodes);
+    const rlpx = this.register(dpt);
+
+    rlpx.on('peer:added', (peer: any) => {
+      this.peerAdded(peer);
+    });
+  }
+}

--- a/src/TxPool/DirectTxPool.ts
+++ b/src/TxPool/DirectTxPool.ts
@@ -14,12 +14,45 @@ export default class DirectTxPool implements ITxPool {
   private static ExecuteData = '61461954';
   private static ClaimData = '4e71d92d';
   private static MaxPeers = 25;
+  private static NetworkStatusMessage = new Map<Networks, any>([
+    [
+      Networks.Mainnet,
+      {
+        networkId: Networks.Mainnet,
+        td: devp2p._util.int2buffer(17179869184), // total difficulty in genesis block
+        bestHash: Buffer.from(
+          'd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3',
+          'hex'
+        ),
+        genesisHash: Buffer.from(
+          'd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3',
+          'hex'
+        )
+      }
+    ],
+    [
+      Networks.Kovan,
+      {
+        networkId: Networks.Kovan,
+        td: devp2p._util.int2buffer(131072), // total difficulty in genesis block
+        bestHash: Buffer.from(
+          'a3c565fc15c7478862d50ccd6561e3c06b24cc509bf388941c25ea985ce32cb9',
+          'hex'
+        ),
+        genesisHash: Buffer.from(
+          'a3c565fc15c7478862d50ccd6561e3c06b24cc509bf388941c25ea985ce32cb9',
+          'hex'
+        )
+      }
+    ]
+  ]);
 
   public pool: Map<string, ITxPoolTxDetails> = new Map<string, ITxPoolTxDetails>();
   private isRunning: boolean = false;
   private web3: Web3;
   private privateKey: Buffer;
   private logger: ILogger;
+  private chainId: Networks;
 
   private dpt: any;
   private rlpx: any;
@@ -38,7 +71,9 @@ export default class DirectTxPool implements ITxPool {
 
   public async start() {
     const chainId = await this.web3.eth.net.getId();
-    if (!this.isRunning && chainId === Networks.Mainnet) {
+
+    if (!this.isRunning && this.isChainSupported(chainId)) {
+      this.chainId = chainId;
       this.startListening();
     }
   }
@@ -47,18 +82,52 @@ export default class DirectTxPool implements ITxPool {
     clearInterval(this.status);
   }
 
+  private isChainSupported(chainId: number) {
+    return chainId === Networks.Mainnet || chainId === Networks.Kovan;
+  }
+
   private get bootNodes() {
-    return bootstrapNodes
-      .filter((node: any) => {
-        return node.chainId === Networks.Mainnet;
-      })
-      .map((node: any) => {
-        return {
-          address: node.ip,
-          udpPort: node.port,
-          tcpPort: node.port
-        };
-      });
+    if (this.chainId === Networks.Mainnet) {
+      return bootstrapNodes
+        .filter((node: any) => {
+          return node.chainId === Networks.Mainnet;
+        })
+        .map((node: any) => {
+          return {
+            address: node.ip,
+            udpPort: node.port,
+            tcpPort: node.port
+          };
+        });
+    } else if (this.chainId === Networks.Kovan) {
+      return [
+        {
+          address: '40.71.221.215',
+          udpPort: 30303,
+          tcpPort: 30303
+        },
+        {
+          address: '52.166.117.77',
+          udpPort: 30303,
+          tcpPort: 30303
+        },
+        {
+          address: '52.165.239.18',
+          udpPort: 30303,
+          tcpPort: 30303
+        },
+        {
+          address: '52.243.47.56',
+          udpPort: 30303,
+          tcpPort: 30303
+        },
+        {
+          address: '40.68.248.100',
+          udpPort: 30303,
+          tcpPort: 30303
+        }
+      ];
+    }
   }
 
   private bootstrap(bootNodes: any[]) {
@@ -100,19 +169,24 @@ export default class DirectTxPool implements ITxPool {
     });
   }
 
-  private sendStatus(eth: any) {
-    eth.sendStatus({
-      networkId: Networks.Mainnet,
-      td: devp2p._util.int2buffer(17179869184), // total difficulty in genesis block
-      bestHash: Buffer.from(
-        'd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3',
-        'hex'
-      ),
-      genesisHash: Buffer.from(
-        'd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3',
-        'hex'
-      )
-    });
+  private async fetchLatestBlockHash(): Promise<Buffer> {
+    const latestBlock = await this.web3.eth.getBlock('latest');
+    return Buffer.from(latestBlock.hash.substring(2), 'hex');
+  }
+
+  private async sendStatus(eth: any) {
+    const message = DirectTxPool.NetworkStatusMessage.get(this.chainId);
+
+    if (message) {
+      message.bestHash = await this.fetchLatestBlockHash();
+      try {
+        eth.sendStatus(message);
+      } catch (error) {
+        this.logger.debug(`[p2p] Send status error ${error.message}`);
+      }
+    } else {
+      throw new Error(`[p2p] Status message not defined for ${this.chainId}`);
+    }
   }
 
   private peerAdded(peer: any) {
@@ -141,6 +215,7 @@ export default class DirectTxPool implements ITxPool {
   }
 
   private onTransaction(payload: any[]) {
+    this.logger.debug(`[p2p] Received ${payload.length} transactions`);
     try {
       for (const rawTx of payload) {
         const tx = new EthereumTx(rawTx);
@@ -172,5 +247,7 @@ export default class DirectTxPool implements ITxPool {
     this.rlpx.on('peer:added', (peer: any) => {
       this.peerAdded(peer);
     });
+
+    this.rlpx.on('error', (error: any) => this.logger.debug(`[p2p] rlpx error ${error.message}`));
   }
 }

--- a/src/TxPool/ITxPool.ts
+++ b/src/TxPool/ITxPool.ts
@@ -1,0 +1,16 @@
+import BigNumber from 'bignumber.js';
+import { Operation } from '../Types/Operation';
+
+export interface ITxPoolTxDetails {
+  to: string;
+  gasPrice: BigNumber;
+  timestamp: number;
+  operation: Operation;
+}
+
+export interface ITxPool {
+  pool: Map<string, ITxPoolTxDetails>;
+  running(): boolean;
+  start(): Promise<void>;
+  stop(): Promise<void>;
+}

--- a/src/TxPool/TxPool.ts
+++ b/src/TxPool/TxPool.ts
@@ -1,33 +1,13 @@
 import { CLAIMED_EVENT, EXECUTED_EVENT } from '../Actions/Helpers';
-import BigNumber from 'bignumber.js';
 import { ILogger } from '../Logger';
-import { Operation } from '../Types/Operation';
 import TxPoolProcessor from './TxPoolProcessor';
 import Web3 = require('web3');
 import { Subscribe, Log, Callback } from 'web3/types';
 import { Util } from '@ethereum-alarm-clock/lib';
+import { ITxPool, ITxPoolTxDetails } from './ITxPool';
 
 const SCAN_INTERVAL = 5000;
 const TIME_IN_POOL = 5 * 60 * 1000;
-
-export interface IFilterTx extends Log {
-  type: string;
-}
-
-export interface ITxPoolTxDetails {
-  to: string;
-  gasPrice: BigNumber;
-  timestamp: number;
-  type: string;
-  operation: Operation;
-}
-
-export interface ITxPool {
-  pool: Map<string, ITxPoolTxDetails>;
-  running(): boolean;
-  start(): Promise<void>;
-  stop(): Promise<void>;
-}
 
 export default class TxPool implements ITxPool {
   public pool: Map<string, ITxPoolTxDetails> = new Map<string, ITxPoolTxDetails>();
@@ -104,9 +84,7 @@ export default class TxPool implements ITxPool {
 
     subscription.on('data', (data: Log) => {
       if (data.topics && data.topics.indexOf(topic) !== -1) {
-        const filterTxData = data as IFilterTx;
-        filterTxData.type = 'pending';
-        this.txPoolProcessor.process(filterTxData, this.pool);
+        this.txPoolProcessor.process(data, this.pool);
       }
     });
 

--- a/src/TxPool/index.ts
+++ b/src/TxPool/index.ts
@@ -1,3 +1,4 @@
-import TxPool, { ITxPoolTxDetails, ITxPool } from './TxPool';
+import TxPool from './TxPool';
+import { ITxPoolTxDetails, ITxPool } from './ITxPool';
 
 export { TxPool, ITxPoolTxDetails, ITxPool };

--- a/src/TxPool/index.ts
+++ b/src/TxPool/index.ts
@@ -1,4 +1,5 @@
+import DirectTxPool from './DirectTxPool';
+import { ITxPool, ITxPoolTxDetails } from './ITxPool';
 import TxPool from './TxPool';
-import { ITxPoolTxDetails, ITxPool } from './ITxPool';
 
-export { TxPool, ITxPoolTxDetails, ITxPool };
+export { DirectTxPool, TxPool, ITxPoolTxDetails, ITxPool };

--- a/src/Types/Operation.ts
+++ b/src/Types/Operation.ts
@@ -1,4 +1,5 @@
 export enum Operation {
   CLAIM,
-  EXECUTE
+  EXECUTE,
+  OTHER
 }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,1 +1,3 @@
 declare module 'ethereumjs-wallet';
+declare module 'ethereum-common';
+declare module 'ethereumjs-devp2p';

--- a/test/unit/UnitTestTxPoolProcessor.ts
+++ b/test/unit/UnitTestTxPoolProcessor.ts
@@ -1,12 +1,13 @@
+import { Util } from '@ethereum-alarm-clock/lib';
 import { BigNumber } from 'bignumber.js';
 import { assert } from 'chai';
 import * as TypeMoq from 'typemoq';
-import { CLAIMED_EVENT, EXECUTED_EVENT } from '../../src/Actions/Helpers';
+import { Log } from 'web3/types';
+
+import { CLAIMED_EVENT } from '../../src/Actions/Helpers';
 import { ITxPoolTxDetails } from '../../src/TxPool';
 import TxPoolProcessor from '../../src/TxPool/TxPoolProcessor';
 import { Operation } from '../../src/Types/Operation';
-import { IFilterTx } from '../../src/TxPool/TxPool';
-import { Util } from '@ethereum-alarm-clock/lib';
 
 describe('TxPoolProcessor Unit Tests', () => {
   function setup(tx: { to: string; gasPrice: BigNumber }) {
@@ -17,16 +18,15 @@ describe('TxPoolProcessor Unit Tests', () => {
     return { processor, pool };
   }
 
-  it('registers tx in pool with pending type', async () => {
+  it('registers tx in pool', async () => {
     const address = '1';
-    const type = 'pending';
     const gasPrice = new BigNumber(10000);
     const transactionHash = '1';
 
     const tx = { to: address, gasPrice };
     const { processor, pool } = setup(tx);
 
-    const filterTx: IFilterTx = {
+    const filterTx: Log = {
       address,
       blockNumber: 1,
       data: '',
@@ -34,8 +34,7 @@ describe('TxPoolProcessor Unit Tests', () => {
       blockHash: '',
       transactionIndex: 0,
       topics: [CLAIMED_EVENT],
-      transactionHash,
-      type
+      transactionHash
     };
 
     await processor.process(filterTx, pool);
@@ -45,39 +44,6 @@ describe('TxPoolProcessor Unit Tests', () => {
     assert.isTrue(pool.has(transactionHash));
     assert.equal(res.operation, Operation.CLAIM);
     assert.equal(res.to, address);
-    assert.equal(res.type, type);
-    assert.isTrue(res.gasPrice.equals(gasPrice));
-  });
-
-  it('registers tx in pool with mined type', async () => {
-    const address = '1';
-    const type = 'mined';
-    const gasPrice = new BigNumber(10000);
-    const transactionHash = '1';
-
-    const tx = { to: address, gasPrice };
-    const { processor, pool } = setup(tx);
-
-    const filterTx: IFilterTx = {
-      address,
-      data: '',
-      transactionIndex: 0,
-      blockHash: '',
-      logIndex: 0,
-      blockNumber: 1,
-      topics: [EXECUTED_EVENT],
-      transactionHash,
-      type
-    };
-
-    await processor.process(filterTx, pool);
-
-    const res = pool.get(transactionHash);
-
-    assert.isTrue(pool.has(transactionHash));
-    assert.equal(res.operation, Operation.EXECUTE);
-    assert.equal(res.to, address);
-    assert.equal(res.type, type);
     assert.isTrue(res.gasPrice.equals(gasPrice));
   });
 });


### PR DESCRIPTION
This aims to improve the pool scanning for pending messages for TimeNodes. 

This implementation utilizes direct access to devp2p ethereum network and listens to pending tx towards EAC contracts. 

Most likely won't work with the browser TimeNode version thus previous implementation based on geth #360 remains as fallback method.

TODO

- [x] Watcher
- [x] Tx decoder
- [x] Integration